### PR TITLE
Background job system with SSE streaming

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,11 @@
+import json
 import os
 import time
 from pathlib import Path
 
 from flask import (
     Flask,
+    Response,
     abort,
     jsonify,
     render_template_string,
@@ -13,7 +15,7 @@ from flask import (
 )
 from werkzeug.utils import secure_filename
 
-from services import sidecar
+from services import jobs, sidecar
 
 # --- Configuration ---
 UPLOAD_FOLDER = os.path.join(os.getcwd(), "uploads")
@@ -565,6 +567,27 @@ HTML_TEMPLATE = """
       {% endif %}
     </section>
   </div>
+  <script>
+    function streamJob(jobId, onProgress, onDone) {
+      var es = new EventSource('/api/jobs/' + encodeURIComponent(jobId));
+      es.onmessage = function(e) {
+        var data = JSON.parse(e.data);
+        if (data.error) {
+          onProgress && onProgress(data);
+          es.close();
+          onDone && onDone({error: data.error});
+          return;
+        }
+        onProgress && onProgress(data);
+        if (data.result !== undefined) {
+          es.close();
+          onDone && onDone({result: data.result});
+        }
+      };
+      es.onerror = function() { es.close(); };
+      return es;
+    }
+  </script>
 </body>
 </html>
 """
@@ -969,6 +992,35 @@ def uploaded_file(filename):
     base = Path(app.config["UPLOAD_FOLDER"]).resolve()
     rel = target.relative_to(base)
     return send_from_directory(str(base), rel.as_posix())
+
+
+@app.route("/api/jobs/<job_id>")
+def job_stream(job_id):
+    job = jobs.get_job(job_id)
+    if job is None:
+        abort(404)
+
+    def generate():
+        for update in jobs.stream_progress(job_id):
+            data = {"progress": update.get("progress", 0), "message": update.get("message", "")}
+            if update.get("result") is not None:
+                data["result"] = update["result"]
+            if update.get("error"):
+                data["error"] = update["error"]
+            yield f"data: {json.dumps(data)}\n\n"
+
+    return Response(generate(), mimetype="text/event-stream")
+
+
+@app.route("/api/jobs/<job_id>/result")
+def job_result(job_id):
+    job = jobs.get_job(job_id)
+    if job is None:
+        abort(404)
+    data = job.to_dict()
+    if data["status"] == "failed":
+        return jsonify({"status": "failed", "error": data.get("error")}), 200
+    return jsonify({"status": data["status"], "result": data.get("result")}), 200
 
 
 if __name__ == "__main__":

--- a/services/jobs.py
+++ b/services/jobs.py
@@ -1,0 +1,143 @@
+"""
+In-process job queue using Python threading.
+
+Provides queue_job(fn, *args) which returns a job ID.
+Each job tracks: id, status, progress, log, result.
+Use get_job(id) to retrieve job state, or stream_progress(id) to get updates.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Iterator
+
+
+class JobStatus(str, Enum):
+    QUEUED = "queued"
+    RUNNING = "running"
+    DONE = "done"
+    FAILED = "failed"
+
+
+@dataclass
+class Job:
+    id: str
+    status: JobStatus = JobStatus.QUEUED
+    progress: int = 0
+    log: list[str] = field(default_factory=list)
+    result: Any = None
+    error: str | None = None
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def set_progress(self, value: int, message: str = "") -> None:
+        with self._lock:
+            self.progress = min(100, max(0, value))
+            if message:
+                self.log.append(message)
+
+    def set_status(self, status: JobStatus) -> None:
+        with self._lock:
+            self.status = status
+
+    def set_result(self, result: Any) -> None:
+        with self._lock:
+            self.result = result
+            self.status = JobStatus.DONE
+            self.progress = 100
+
+    def set_error(self, error: str) -> None:
+        with self._lock:
+            self.error = error
+            self.status = JobStatus.FAILED
+
+    def to_dict(self) -> dict:
+        with self._lock:
+            return {
+                "id": self.id,
+                "status": self.status.value,
+                "progress": self.progress,
+                "log": list(self.log),
+                "result": self.result,
+                "error": self.error,
+            }
+
+
+_jobs: dict[str, Job] = {}
+_jobs_lock = threading.Lock()
+_executor = threading.Thread(target=lambda: None)
+_executor.daemon = True
+
+
+def queue_job(fn: Callable, *args, **kwargs) -> str:
+    """
+    Queue a job to run in a background thread.
+    Returns the job ID.
+    """
+    job_id = str(uuid.uuid4())[:8]
+    job = Job(id=job_id)
+    with _jobs_lock:
+        _jobs[job_id] = job
+
+    def run():
+        job.set_status(JobStatus.RUNNING)
+        try:
+            result = fn(job, *args, **kwargs)
+            job.set_result(result)
+        except Exception as exc:
+            job.set_error(str(exc))
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    return job_id
+
+
+def get_job(job_id: str) -> Job | None:
+    """Return the Job object for the given ID, or None if not found."""
+    with _jobs_lock:
+        return _jobs.get(job_id)
+
+
+def stream_progress(job_id: str) -> Iterator[dict]:
+    """Yield progress updates for a job as dicts (for SSE)."""
+    seen_indices: dict[str, int] = {job_id: 0}
+    last_status = None
+
+    while True:
+        job = get_job(job_id)
+        if job is None:
+            return
+
+        with job._lock:
+            current_status = job.status
+            current_log = list(job.log)
+            current_progress = job.progress
+            current_result = job.result
+            current_error = job.error
+
+        if current_status in (JobStatus.DONE, JobStatus.FAILED):
+            yield {
+                "status": current_status.value,
+                "progress": current_progress,
+                "message": "",
+                "result": current_result,
+                "error": current_error,
+            }
+            return
+
+        start_idx = seen_indices.get(job_id, 0)
+        for i in range(start_idx, len(current_log)):
+            yield {
+                "status": current_status.value,
+                "progress": current_progress,
+                "message": current_log[i],
+            }
+        seen_indices[job_id] = len(current_log)
+
+        if current_status != last_status:
+            last_status = current_status
+
+        time.sleep(0.1)


### PR DESCRIPTION
## Summary
- Added `services/jobs.py` with in-process job queue using Python threading
- `queue_job(fn, *args)` returns a job ID and runs the function in a background thread
- Jobs track: id, status (queued/running/done/failed), progress (0-100), log, result
- Added `GET /api/jobs/<id>` SSE endpoint for real-time progress streaming
- Added `GET /api/jobs/<id>/result` endpoint for fetching final job result
- Added `streamJob(jobId, onProgress, onDone)` JS helper for browser-side SSE consumption

## Details
- `services/jobs.py`: Job dataclass with thread-safe state updates, `queue_job()` for background execution, `stream_progress()` generator for SSE
- SSE format: `data: {"progress": 42, "message": "[3/10] photo.jpg ... YES"}`
- JS helper uses EventSource, handles errors, calls callbacks on progress updates and completion