### PR TITLE
LM Studio service layer (issue #3)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+import threading
 import json
 import os
 import time
@@ -15,7 +16,7 @@ from flask import (
 )
 from werkzeug.utils import secure_filename
 
-from services import jobs, sidecar
+from services import jobs, sidecar, lmstudio
 
 # --- Configuration ---
 UPLOAD_FOLDER = os.path.join(os.getcwd(), "uploads")
@@ -495,7 +496,7 @@ HTML_TEMPLATE = """
 <body>
   <div class="wrap">
     <header>
-      <h1>Upload files</h1>
+      <h1>Upload files <span id="lms-status" style="display:inline-block;width:8px;height:8px;border-radius:50%;background:#f44336;vertical-align:middle;margin-left:6px;"></span></h1>
       <p class="lede">txt, pdf, png, jpg, jpeg, gif — multiple files allowed</p>
     </header>
     <section class="card" aria-labelledby="upload-heading">
@@ -587,6 +588,20 @@ HTML_TEMPLATE = """
       es.onerror = function() { es.close(); };
       return es;
     }
+    (function() {
+      var dot = document.getElementById('lms-status');
+      if (!dot) return;
+      function poll() {
+        fetch('/api/lmstudio/status')
+          .then(function(r) { return r.json(); })
+          .then(function(d) {
+            dot.style.background = (d.server === 'up' && d.model === 'loaded') ? '#4caf50' : '#f44336';
+          })
+          .catch(function() { dot.style.background = '#f44336'; });
+      }
+      poll();
+      setInterval(poll, 5000);
+    })();
   </script>
 </body>
 </html>
@@ -1023,5 +1038,25 @@ def job_result(job_id):
     return jsonify({"status": data["status"], "result": data.get("result")}), 200
 
 
+@app.route("/api/lmstudio/status")
+def lmstudio_status():
+    base = os.environ.get("LMSTUDIO_BASE", "http://127.0.0.1:1234/v1")
+    model = os.environ.get("LMSTUDIO_MODEL", "")
+    server = "up" if lmstudio.server_is_up(base) else "down"
+    model_state = "unloaded"
+    if server == "up" and model:
+        model_state = "loaded" if lmstudio.model_is_loaded(base, model) else "unloaded"
+    return jsonify({"server": server, "model": model_state})
+
+
+def _start_lmstudio_background():
+    base = os.environ.get("LMSTUDIO_BASE", "http://127.0.0.1:1234/v1")
+    model = os.environ.get("LMSTUDIO_MODEL", "")
+    if model:
+        t = threading.Thread(target=lambda: lmstudio.ensure_ready(base, model), daemon=True)
+        t.start()
+
+
 if __name__ == "__main__":
+    _start_lmstudio_background()
     app.run(host="0.0.0.0", port=8080)

--- a/services/lmstudio.py
+++ b/services/lmstudio.py
@@ -1,0 +1,54 @@
+import json
+import os
+import subprocess
+import time
+import urllib.error
+import urllib.request
+
+LMS = "lms"
+
+LMSTUDIO_BASE = os.environ.get("LMSTUDIO_BASE", "http://127.0.0.1:1234/v1")
+LMSTUDIO_API_KEY = os.environ.get("LMSTUDIO_API_KEY", "lm-studio")
+LMSTUDIO_MODEL = os.environ.get("LMSTUDIO_MODEL", "")
+
+
+def server_is_up(base_url: str = LMSTUDIO_BASE) -> bool:
+    try:
+        with urllib.request.urlopen(base_url.rstrip("/") + "/models", timeout=3):
+            return True
+    except Exception:
+        return False
+
+
+def model_is_loaded(base_url: str = LMSTUDIO_BASE, model: str = LMSTUDIO_MODEL) -> bool:
+    if not model:
+        return False
+    try:
+        with urllib.request.urlopen(base_url.rstrip("/") + "/models", timeout=5) as r:
+            data = json.loads(r.read())
+        return any(m.get("id") == model for m in data.get("data", []))
+    except Exception:
+        return False
+
+
+def _run_lms(*args: str) -> bool:
+    try:
+        result = subprocess.run([LMS, *args])
+        return result.returncode == 0
+    except FileNotFoundError:
+        return False
+
+
+def ensure_ready(base_url: str = LMSTUDIO_BASE, model: str = LMSTUDIO_MODEL) -> None:
+    if not server_is_up(base_url):
+        if not _run_lms("server", "start"):
+            raise RuntimeError("Could not start LM Studio server.")
+        for _ in range(15):
+            time.sleep(1)
+            if server_is_up(base_url):
+                break
+        else:
+            raise RuntimeError(f"LM Studio server did not respond at {base_url} after 15 s.")
+    if not model_is_loaded(base_url, model):
+        if not _run_lms("load", model):
+            raise RuntimeError(f"Could not load model '{model}'.")


### PR DESCRIPTION
## Summary
Extract the ensure_lmstudio_ready logic from the CLI scripts into a Flask-accessible module (services/lmstudio.py). Auto-start the LM Studio server and load the model on app startup. Expose a status endpoint consumed by the nav bar.

## Changes
- Created `services/lmstudio.py` with `ensure_ready()`, `server_is_up()`, `model_is_loaded()` functions
- Added `GET /api/lmstudio/status` → `{"server": "up|down", "model": "loaded|unloaded"}`
- Added green/red status dot to nav bar with JS polling every 5 seconds
- Added background thread startup to auto-start LM Studio on Flask launch

## Testing
- App starts LM Studio automatically on launch (if LMSTUDIO_MODEL is set)
- `/api/lmstudio/status` returns correct state
- Nav dot is green when ready, red when not

## Dependencies
- Uses environment variables: `LMSTUDIO_BASE`, `LMSTUDIO_MODEL`, `LMSTUDIO_API_KEY`

closes #3