### PR TITLE
Person detail page (closes #8)

### DIFF
--- a/app.py
+++ b/app.py
@@ -406,7 +406,52 @@ def delete_person(person_id):
 
 @app.route("/people/<person_id>")
 def person_detail(person_id):
-    abort(404)
+    person_dir = os.path.join(PEOPLE_FOLDER, person_id)
+    person_file = os.path.join(person_dir, "person.json")
+
+    if not os.path.isfile(person_file):
+        abort(404)
+
+    with open(person_file, "r", encoding="utf-8") as f:
+        person = json.load(f)
+    person["id"] = person_id
+
+    tagged_results = sidecar.search(Path(UPLOAD_FOLDER), person.get("name", ""))
+    tagged_photos = [(path, meta) for path, meta in tagged_results]
+
+    return render_template(
+        "person_detail.html",
+        person=person,
+        tagged_photos=tagged_photos,
+        tagged_count=len(tagged_photos),
+    )
+
+
+@app.route("/people/<person_id>/add-photo", methods=["POST"])
+def add_person_photo(person_id):
+    person_dir = os.path.join(PEOPLE_FOLDER, person_id)
+    person_file = os.path.join(person_dir, "person.json")
+
+    if not os.path.isfile(person_file):
+        abort(404)
+
+    photo = request.files.get("photo")
+    if not photo or not photo.filename:
+        abort(400)
+
+    ext = photo.filename.rsplit(".", 1)[-1].lower() if "." in photo.filename else "jpg"
+    safe_name = secure_filename(f"{uuid.uuid4().hex}.{ext}")
+    photo.save(os.path.join(person_dir, safe_name))
+
+    with open(person_file, "r", encoding="utf-8") as f:
+        person = json.load(f)
+
+    person["reference_photos"] = person.get("reference_photos", []) + [safe_name]
+
+    with open(person_file, "w", encoding="utf-8") as f:
+        json.dump(person, f, indent=2)
+
+    return redirect(url_for("person_detail", person_id=person_id))
 
 
 @app.route("/people/ref/<person_id>/<filename>")

--- a/templates/person_detail.html
+++ b/templates/person_detail.html
@@ -1,0 +1,270 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="theme-color" content="#0f1419">
+  <title>{{ person.name | e }} - People</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0f1419;
+      --bg-elevated: #1a2332;
+      --bg-input: #243044;
+      --border: #2d3a4d;
+      --text: #e7ecf3;
+      --text-muted: #8b9aad;
+      --accent: #5b9fd4;
+      --accent-hover: #7eb6e8;
+      --danger: #d45b5b;
+      --danger-hover: #e87c7c;
+      --radius: 12px;
+      --tap-min: 44px;
+      --font: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+    }
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100dvh;
+      font-family: var(--font);
+      font-size: 1rem;
+      line-height: 1.5;
+      color: var(--text);
+      background: var(--bg);
+      -webkit-font-smoothing: antialiased;
+      padding:
+        max(1rem, env(safe-area-inset-top))
+        max(1rem, env(safe-area-inset-right))
+        max(1.25rem, env(safe-area-inset-bottom))
+        max(1rem, env(safe-area-inset-left));
+    }
+    .wrap { width: 100%; max-width: 28rem; margin: 0 auto; }
+    nav {
+      display: flex;
+      gap: 0;
+      margin-bottom: 1.5rem;
+      border: 1px solid var(--border);
+      border-radius: calc(var(--radius) - 4px);
+      overflow: hidden;
+    }
+    nav a {
+      flex: 1;
+      text-align: center;
+      padding: 0.65rem 0.5rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      text-decoration: none;
+      background: var(--bg-input);
+    }
+    nav a.is-active {
+      color: var(--text);
+      background: var(--bg-elevated);
+      box-shadow: inset 0 -2px 0 0 var(--accent);
+    }
+    nav a + a { border-left: 1px solid var(--border); }
+    nav a:hover:not(.is-active) { color: var(--text); }
+    .back {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      margin-bottom: 1rem;
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      text-decoration: none;
+    }
+    .back:hover { color: var(--text); }
+    header {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      margin-bottom: 1.5rem;
+    }
+    h1 {
+      font-size: clamp(1.35rem, 4vw, 1.6rem);
+      font-weight: 600;
+      letter-spacing: -0.02em;
+      margin: 0;
+    }
+    .subtitle {
+      font-size: 0.9rem;
+      color: var(--text-muted);
+    }
+    .actions {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+    .btn {
+      min-height: var(--tap-min);
+      padding: 0 1.1rem;
+      font-size: 1rem;
+      font-weight: 600;
+      font-family: inherit;
+      color: var(--bg);
+      background: var(--accent);
+      border: none;
+      border-radius: calc(var(--radius) - 4px);
+      cursor: pointer;
+      text-align: center;
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .btn:hover { background: var(--accent-hover); }
+    .btn:active { transform: scale(0.98); }
+    .btn-secondary {
+      background: var(--bg-input);
+      color: var(--text);
+      border: 1px solid var(--border);
+    }
+    .btn-secondary:hover { background: var(--bg-elevated); border-color: var(--accent); }
+    .btn-danger {
+      background: var(--danger);
+      color: #fff;
+    }
+    .btn-danger:hover { background: var(--danger-hover); }
+    .section {
+      margin-bottom: 2rem;
+    }
+    .section-title {
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      margin: 0 0 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .ref-photos {
+      display: flex;
+      gap: 0.5rem;
+      overflow-x: auto;
+      padding-bottom: 0.5rem;
+      -webkit-overflow-scrolling: touch;
+    }
+    .ref-photo {
+      flex-shrink: 0;
+      width: 5rem;
+      height: 5rem;
+      border-radius: calc(var(--radius) - 4px);
+      overflow: hidden;
+      background: var(--bg-input);
+    }
+    .ref-photo img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+    .add-photo-form {
+      display: flex;
+      gap: 0.5rem;
+      margin-top: 0.75rem;
+    }
+    .add-photo-form input[type="file"] {
+      font-size: 0.85rem;
+      color: var(--text-muted);
+    }
+    .add-photo-form input[type="file"]::file-selector-button {
+      padding: 0 0.75rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: var(--text);
+      background: var(--bg-input);
+      border: 1px solid var(--border);
+      border-radius: calc(var(--radius) - 4px);
+      cursor: pointer;
+    }
+    .add-photo-form .btn {
+      padding: 0 0.75rem;
+      font-size: 0.85rem;
+      min-height: 2.25rem;
+    }
+    .photos-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 0.35rem;
+    }
+    @media (min-width: 400px) {
+      .photos-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 0.5rem; }
+    }
+    .photo-thumb {
+      aspect-ratio: 1;
+      background: #0a0e14;
+      border-radius: calc(var(--radius) - 4px);
+      overflow: hidden;
+    }
+    .photo-thumb img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+    .empty {
+      margin: 0;
+      padding: 1.5rem 1rem;
+      text-align: center;
+      font-size: 0.9rem;
+      color: var(--text-muted);
+      border: 1px dashed var(--border);
+      border-radius: calc(var(--radius) - 4px);
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <nav>
+      <a href="{{ url_for('upload_form') }}">Library</a>
+      <a href="{{ url_for('people_page') }}" class="is-active">People</a>
+      <a href="#">Search</a>
+    </nav>
+    <a class="back" href="{{ url_for('people_page') }}">&larr; People</a>
+    <header>
+      <h1>{{ person.name | e }}</h1>
+      <p class="subtitle">{{ tagged_count }} photo{% if tagged_count != 1 %}s{% endif %} tagged</p>
+      <div class="actions">
+        <a class="btn" href="{{ url_for('edit_person', person_id=person.id) }}">Edit</a>
+        <form method="POST" action="{{ url_for('delete_person', person_id=person.id) }}" style="display:inline">
+          <button class="btn btn-danger" type="submit" onclick="return confirm('Delete this person?')">Delete</button>
+        </form>
+        <a class="btn btn-secondary" href="#">Find in library</a>
+      </div>
+    </header>
+
+    <div class="section">
+      <h2 class="section-title">Reference Photos</h2>
+      <div class="ref-photos">
+        {% if person.reference_photos %}
+          {% for photo in person.reference_photos %}
+          <div class="ref-photo">
+            <img src="{{ url_for('person_ref_photo', person_id=person.id, filename=photo) }}" alt="" loading="lazy">
+          </div>
+          {% endfor %}
+        {% else %}
+          <div class="empty">No reference photos</div>
+        {% endif %}
+      </div>
+      <form class="add-photo-form" method="POST" action="{{ url_for('add_person_photo', person_id=person.id) }}" enctype="multipart/form-data">
+        <input type="file" name="photo" accept="image/*" required>
+        <button class="btn" type="submit">Add reference photo</button>
+      </form>
+    </div>
+
+    <div class="section">
+      <h2 class="section-title">Tagged Photos</h2>
+      {% if tagged_photos %}
+      <div class="photos-grid">
+        {% for path, meta in tagged_photos %}
+        <a class="photo-thumb" href="{{ url_for('file_detail', filename=path.name) }}">
+          <img src="{{ url_for('uploaded_file', filename=path.name) }}" alt="" loading="lazy">
+        </a>
+        {% endfor %}
+      </div>
+      {% else %}
+      <div class="empty">No photos tagged with this person</div>
+      {% endif %}
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Implements the person detail page (`/people/<id>`) as specified in issue #8.

- Reference photos displayed in a horizontal scroll row at top
- Tagged photos grid showing all photos where the person is tagged (using `sidecar.search()`)
- "Add reference photo" inline upload form that POSTs to `/people/<id>/add-photo`
- Edit and Delete buttons with proper actions
- Tagged photo count shown in header
- "Find in library" button as placeholder (`href="#"`)

## Changes
- Created `templates/person_detail.html` with dark mobile-first styling matching existing pages
- Implemented `person_detail()` route to load person data and tagged photos
- Added `POST /people/<person_id>/add-photo` endpoint to add reference photos