### PR TITLE
Auto-describe photos on upload (closes #9)

### DIFF
--- a/app.py
+++ b/app.py
@@ -233,7 +233,7 @@ def _normalize_view_mode(raw) -> str:
 
 
 def _render_upload_page(
-    upload_message=None, upload_status="ok", view_mode="thumb"
+    upload_message=None, upload_status="ok", view_mode="thumb", describe_job_id=None
 ):
     return render_template(
         "library.html",
@@ -241,6 +241,7 @@ def _render_upload_page(
         upload_message=upload_message,
         upload_status=upload_status,
         view_mode=view_mode,
+        describe_job_id=describe_job_id,
     )
 
 
@@ -282,7 +283,33 @@ def upload_file():
         parts.append(
             "Skipped: " + "; ".join(f"{n} ({reason})" for n, reason in rejected)
         )
-    return _render_upload_page(" ".join(parts), "ok", vm), 200
+
+    describe_job_id = None
+    images_needing_desc = []
+    for fname in saved:
+        ext = fname.rsplit(".", 1)[-1].lower() if "." in fname else ""
+        if ext not in IMAGE_EXTENSIONS:
+            continue
+        fpath = Path(app.config["UPLOAD_FOLDER"]) / fname
+        if sidecar.read_desc_cache(fpath) is None:
+            images_needing_desc.append(str(fpath))
+
+    if images_needing_desc:
+        base_url = os.environ.get("LMSTUDIO_BASE", "http://127.0.0.1:1234/v1")
+        model = os.environ.get("LMSTUDIO_MODEL", "")
+        api_key = os.environ.get("LMSTUDIO_API_KEY", "lm-studio")
+        if model:
+            lmstudio.ensure_ready(base_url, model)
+            describe_job_id = jobs.queue_job(
+                lmstudio.describe_new_photos,
+                images_needing_desc,
+                base_url,
+                model,
+                api_key,
+            )
+
+    msg = " ".join(parts)
+    return _render_upload_page(msg, "ok", vm, describe_job_id), 200
 
 
 @app.route("/delete", methods=["POST"])

--- a/services/lmstudio.py
+++ b/services/lmstudio.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import os
 import subprocess
@@ -10,6 +11,74 @@ LMS = "lms"
 LMSTUDIO_BASE = os.environ.get("LMSTUDIO_BASE", "http://127.0.0.1:1234/v1")
 LMSTUDIO_API_KEY = os.environ.get("LMSTUDIO_API_KEY", "lm-studio")
 LMSTUDIO_MODEL = os.environ.get("LMSTUDIO_MODEL", "")
+
+
+def describe_photo(image_path: str, base_url: str, model: str, api_key: str) -> str | None:
+    """
+    Send an image to LM Studio and get a description.
+    Returns the description text, or None on failure.
+    """
+    try:
+        with open(image_path, "rb") as f:
+            img_data = base64.b64encode(f.read()).decode("utf-8")
+    except Exception:
+        return None
+
+    prompt = "Describe this photo in 1-2 sentences. Focus on people, setting, and activity."
+    payload = {
+        "model": model,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": prompt},
+                    {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{img_data}"}}
+                ]
+            }
+        ],
+        "max_tokens": 200,
+    }
+
+    req = urllib.request.Request(
+        base_url.rstrip("/") + "/chat/completions",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            data = json.loads(resp.read())
+        return data.get("choices", [{}])[0].get("message", {}).get("content", "").strip()
+    except Exception:
+        return None
+
+
+def describe_new_photos(job, image_paths: list[str], base_url: str, model: str, api_key: str) -> dict:
+    """
+    Background job to describe new photos.
+    job: Job object with set_progress method
+    image_paths: list of image file paths (full paths)
+    """
+    from services import sidecar
+
+    total = len(image_paths)
+    results = {"described": [], "failed": []}
+
+    for idx, path in enumerate(image_paths):
+        job.set_progress(int((idx / total) * 100), f"Describing {idx + 1}/{total}...")
+        desc = describe_photo(path, base_url, model, api_key)
+        if desc:
+            sidecar.write_desc_cache(path, {"description": desc})
+            results["described"].append(path)
+        else:
+            results["failed"].append(path)
+
+    job.set_progress(100, f"Done: {len(results['described'])} described, {len(results['failed'])} failed")
+    return results
 
 
 def server_is_up(base_url: str = LMSTUDIO_BASE) -> bool:

--- a/templates/library.html
+++ b/templates/library.html
@@ -310,6 +310,26 @@
       width: 100%;
       font-size: 0.8rem;
     }
+    .progress-bar {
+      margin: 0 0 0.75rem;
+      padding: 0.65rem 0.85rem;
+      border-radius: calc(var(--radius) - 4px);
+      font-size: 0.9rem;
+      line-height: 1.4;
+      color: #90caf9;
+      background: rgba(33, 150, 243, 0.15);
+      border: 1px solid rgba(33, 150, 243, 0.45);
+      display: none;
+    }
+    .progress-bar.visible { display: block; }
+    .progress-bar .progress-fill {
+      display: block;
+      height: 4px;
+      background: #42a5f5;
+      border-radius: 2px;
+      margin-top: 0.4rem;
+      transition: width 0.2s;
+    }
   </style>
 </head>
 <body>
@@ -337,6 +357,12 @@
         <p class="hint">Choose one or more files (e.g. Shift/Ctrl/Cmd+click). Stored on the server.</p>
       </form>
     </section>
+    {% if describe_job_id %}
+    <div id="describe-progress" class="progress-bar visible" role="status" aria-live="polite">
+      <span id="describe-msg">Describing photos…</span>
+      <div class="progress-fill" id="describe-fill" style="width:0%"></div>
+    </div>
+    {% endif %}
     <section aria-labelledby="files-heading">
       <h2 id="files-heading">Uploaded files</h2>
       <div class="view-switch" role="group" aria-label="How to show files">
@@ -425,6 +451,32 @@
       }
       poll();
       setInterval(poll, 5000);
+    })();
+    (function() {
+      var jobId = {{ describe_job_id|tojson }};
+      if (!jobId) return;
+      var bar = document.getElementById('describe-progress');
+      var msg = document.getElementById('describe-msg');
+      var fill = document.getElementById('describe-fill');
+      streamJob(jobId, function(data) {
+        if (data.message) {
+          msg.textContent = data.message;
+        }
+        if (typeof data.progress === 'number') {
+          fill.style.width = data.progress + '%';
+        }
+      }, function(done) {
+        if (done.error) {
+          msg.textContent = 'Failed: ' + done.error;
+          bar.style.color = '#ffcdd2';
+          bar.style.background = 'rgba(229, 57, 53, 0.15)';
+          bar.style.borderColor = 'rgba(229, 57, 53, 0.45)';
+        } else if (done.result && done.result.failed && done.result.failed.length) {
+          msg.textContent = 'Described ' + done.result.described.length + ', failed ' + done.result.failed.length;
+        } else {
+          bar.style.display = 'none';
+        }
+      });
     })();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Added `describe_photo()` helper that POSTs images to LM Studio and returns description text
- Added `describe_new_photos()` background job that iterates images, calls describe_photo, writes desc_cache, updates progress
- Modified upload route to queue a describe job for images missing a .desc_cache entry
- Added progress bar to library.html that shows during analysis and auto-dismisses on completion
- On failure, shows which photos could not be described

## Changes
- `services/lmstudio.py`: Added `describe_photo` and `describe_new_photos` functions
- `app.py`: Modified `_render_upload_page` and `upload_file` to queue describe jobs
- `templates/library.html`: Added progress bar UI with streamJob polling

## Testing
- Manual: Upload images and verify progress bar appears and auto-dismisses