### PR TITLE
Visual person matching endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -573,6 +573,31 @@ def job_result(job_id):
     return jsonify({"status": data["status"], "result": data.get("result")}), 200
 
 
+@app.route("/api/people/<person_id>/find", methods=["POST"])
+def find_person_in_library(person_id):
+    person_dir = os.path.join(PEOPLE_FOLDER, person_id)
+    person_file = os.path.join(person_dir, "person.json")
+
+    if not os.path.isfile(person_file):
+        abort(404)
+
+    base_url = os.environ.get("LMSTUDIO_BASE", "http://127.0.0.1:1234/v1")
+    model = os.environ.get("LMSTUDIO_MODEL", "")
+    api_key = os.environ.get("LMSTUDIO_API_KEY", "lm-studio")
+
+    job_id = jobs.queue_job(
+        lmstudio.match_person_in_library,
+        person_id,
+        PEOPLE_FOLDER,
+        UPLOAD_FOLDER,
+        base_url,
+        model,
+        api_key,
+    )
+
+    return jsonify({"job_id": job_id}), 202
+
+
 @app.route("/api/lmstudio/status")
 def lmstudio_status():
     base = os.environ.get("LMSTUDIO_BASE", "http://127.0.0.1:1234/v1")

--- a/services/jobs.py
+++ b/services/jobs.py
@@ -31,11 +31,17 @@ class Job:
     log: list[str] = field(default_factory=list)
     result: Any = None
     error: str | None = None
+    current_file: str | None = None
+    answer: str | None = None
     _lock: threading.Lock = field(default_factory=threading.Lock)
 
-    def set_progress(self, value: int, message: str = "") -> None:
+    def set_progress(self, value: int, message: str = "", current_file: str | None = None, answer: str | None = None) -> None:
         with self._lock:
             self.progress = min(100, max(0, value))
+            if current_file is not None:
+                self.current_file = current_file
+            if answer is not None:
+                self.answer = answer
             if message:
                 self.log.append(message)
 
@@ -63,6 +69,8 @@ class Job:
                 "log": list(self.log),
                 "result": self.result,
                 "error": self.error,
+                "current_file": self.current_file,
+                "answer": self.answer,
             }
 
 
@@ -125,6 +133,8 @@ def stream_progress(job_id: str) -> Iterator[dict]:
                 "message": "",
                 "result": current_result,
                 "error": current_error,
+                "current_file": job.current_file,
+                "answer": job.answer,
             }
             return
 
@@ -134,6 +144,8 @@ def stream_progress(job_id: str) -> Iterator[dict]:
                 "status": current_status.value,
                 "progress": current_progress,
                 "message": current_log[i],
+                "current_file": job.current_file,
+                "answer": job.answer,
             }
         seen_indices[job_id] = len(current_log)
 

--- a/services/lmstudio.py
+++ b/services/lmstudio.py
@@ -121,3 +121,150 @@ def ensure_ready(base_url: str = LMSTUDIO_BASE, model: str = LMSTUDIO_MODEL) -> 
     if not model_is_loaded(base_url, model):
         if not _run_lms("load", model):
             raise RuntimeError(f"Could not load model '{model}'.")
+
+
+def _load_image_base64(image_path: str) -> str | None:
+    try:
+        with open(image_path, "rb") as f:
+            return base64.b64encode(f.read()).decode("utf-8")
+    except Exception:
+        return None
+
+
+def _compare_two_photos(
+    ref_path: str,
+    candidate_path: str,
+    person_name: str,
+    base_url: str,
+    model: str,
+    api_key: str,
+) -> str | None:
+    ref_b64 = _load_image_base64(ref_path)
+    candidate_b64 = _load_image_base64(candidate_path)
+    if not ref_b64 or not candidate_b64:
+        return None
+
+    prompt = f"Image 1 is a reference photo of {person_name}. Is this same person visible in Image 2? Answer YES or NO then one sentence."
+    payload = {
+        "model": model,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": prompt},
+                    {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{ref_b64}"}},
+                    {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{candidate_b64}"}},
+                ]
+            }
+        ],
+        "max_tokens": 100,
+    }
+
+    req = urllib.request.Request(
+        base_url.rstrip("/") + "/chat/completions",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            data = json.loads(resp.read())
+        return data.get("choices", [{}])[0].get("message", {}).get("content", "").strip()
+    except Exception:
+        return None
+
+
+def match_person_in_library(
+    job,
+    person_id: str,
+    people_folder: str,
+    uploads_folder: str,
+    base_url: str,
+    model: str,
+    api_key: str,
+) -> dict:
+    """
+    Background job to find all photos of a person in the uploads library.
+    job: Job object with set_progress method
+    person_id: UUID of the person
+    people_folder: Path to people directory
+    uploads_folder: Path to uploads directory
+    """
+    person_file = os.path.join(people_folder, person_id, "person.json")
+    if not os.path.isfile(person_file):
+        raise FileNotFoundError(f"Person not found: {person_id}")
+
+    with open(person_file, "r", encoding="utf-8") as f:
+        person = json.load(f)
+
+    name = person.get("name", "Unknown")
+    reference_photos = person.get("reference_photos", [])
+    if not reference_photos:
+        raise ValueError(f"No reference photos for person: {person_id}")
+
+    ref_path = os.path.join(people_folder, person_id, reference_photos[0])
+
+    files = [
+        f
+        for f in os.listdir(uploads_folder)
+        if os.path.isfile(os.path.join(uploads_folder, f))
+        and not f.startswith(".")
+        and not f.endswith(".meta.json")
+        and f != "_set_unique.meta.json"
+        and not f.endswith(".desc_cache")
+    ]
+
+    total = len(files)
+    if total == 0:
+        job.set_progress(100, "No files to scan.")
+        return {"matches": [], "no_match": [], "failed": []}
+
+    matches = []
+    no_match = []
+    failed = []
+
+    for idx, filename in enumerate(files):
+        ensure_ready(base_url, model)
+
+        candidate_path = os.path.join(uploads_folder, filename)
+        job.set_progress(
+            int((idx / total) * 100),
+            f"[{idx + 1}/{total}] {filename} ...",
+            current_file=filename,
+        )
+
+        answer = _compare_two_photos(ref_path, candidate_path, name, base_url, model, api_key)
+
+        if answer is None:
+            failed.append(filename)
+            job.set_progress(
+                int((idx / total) * 100),
+                f"[{idx + 1}/{total}] {filename} ... FAILED",
+                current_file=filename,
+                answer="FAILED",
+            )
+        elif answer.upper().startswith("YES"):
+            matches.append(filename)
+            job.set_progress(
+                int((idx / total) * 100),
+                f"[{idx + 1}/{total}] {filename} ... YES",
+                current_file=filename,
+                answer="YES",
+            )
+        else:
+            no_match.append(filename)
+            job.set_progress(
+                int((idx / total) * 100),
+                f"[{idx + 1}/{total}] {filename} ... NO",
+                current_file=filename,
+                answer="NO",
+            )
+
+        time.sleep(0.5)
+
+    job.set_progress(100, f"Done: {len(matches)} matches, {len(no_match)} no match, {len(failed)} failed")
+    return {"matches": matches, "no_match": no_match, "failed": failed}


### PR DESCRIPTION
## Summary
- Added POST `/api/people/<person_id>/find` endpoint that queues a background job
- Implemented `match_person_in_library` function in `services/lmstudio.py`:
  - Compares reference photo against every image in uploads/
  - Sends both images to LM Studio with YES/NO prompt
  - Auto-recovers if LM Studio crashes mid-scan via `ensure_ready()` before each image
  - 0.5s pause between requests to avoid overloading
  - Progress updates include current_file and answer (YES/NO/FAILED)
- Extended `Job` class with `current_file` and `answer` fields for detailed progress

## Progress SSE format
```json
{"progress": 40, "message": "[4/10] photo.jpg ... YES", "current_file": "photo.jpg", "answer": "YES"}
```

## Final result
```json
{"matches": ["a.jpg", "b.jpg"], "no_match": ["c.jpg"], "failed": []}
```