### PR TITLE
Search page with text mode (closes #12)

### DIFF
--- a/app.py
+++ b/app.py
@@ -570,6 +570,48 @@ def person_ref_photo(person_id, filename):
     return send_from_directory(os.path.join(PEOPLE_FOLDER, person_id), safe_filename)
 
 
+def _find_match_reason(meta, query):
+    """Return the first sidecar field that matched the query."""
+    if not meta:
+        return None
+    query_lower = query.lower()
+    keywords = query_lower.split()
+    search_fields = ["people", "event", "date", "location", "notes", "subject", "source"]
+    for field in search_fields:
+        value = meta.get(field)
+        if value is None:
+            continue
+        if isinstance(value, list):
+            for v in value:
+                if query_lower in str(v).lower():
+                    return f"{field.title()}: {v}"
+        elif isinstance(value, str):
+            for kw in keywords:
+                if kw in value.lower():
+                    return f"{field.title()}: {value[:80]}{'...' if len(value) > 80 else ''}"
+    return None
+
+
+@app.route("/search")
+def search_page():
+    query = request.args.get("q", "").strip()
+    mode = request.args.get("mode", "text")
+
+    if mode == "person":
+        return render_template("search.html", query=query, mode=mode, results=[])
+
+    if not query:
+        return render_template("search.html", query=None, mode=mode, results=[])
+
+    raw_results = sidecar.search(Path(UPLOAD_FOLDER), query)
+    results = []
+    for path, meta in raw_results:
+        match_reason = _find_match_reason(meta, query)
+        results.append((path, meta, match_reason))
+
+    return render_template("search.html", query=query, mode=mode, results=results)
+
+
 @app.route("/file/<path:filename>")
 def file_detail(filename):
     target = _resolved_upload_target(filename)

--- a/templates/detail.html
+++ b/templates/detail.html
@@ -180,7 +180,7 @@
     <nav>
       <a href="{{ url_for('upload_form') }}" class="is-active">Library</a>
       <a href="{{ url_for('people_page') }}">People</a>
-      <a href="#">Search</a>
+      <a href="{{ url_for('search_page') }}">Search</a>
     </nav>
     <a class="back" href="{{ url_for('upload_form', view=view_mode) }}">← All files</a>
     <h1>{{ filename|e }}</h1>

--- a/templates/library.html
+++ b/templates/library.html
@@ -337,7 +337,7 @@
     <nav>
       <a href="{{ url_for('upload_form') }}" class="is-active">Library</a>
       <a href="{{ url_for('people_page') }}">People</a>
-      <a href="#">Search</a>
+      <a href="{{ url_for('search_page') }}">Search</a>
     </nav>
     <header>
       <h1>Upload files <span id="lms-status" style="display:inline-block;width:8px;height:8px;border-radius:50%;background:#f44336;vertical-align:middle;margin-left:6px;"></span></h1>

--- a/templates/people.html
+++ b/templates/people.html
@@ -176,7 +176,7 @@
     <nav>
       <a href="{{ url_for('upload_form') }}">Library</a>
       <a href="{{ url_for('people_page') }}" class="is-active">People</a>
-      <a href="#">Search</a>
+      <a href="{{ url_for('search_page') }}">Search</a>
     </nav>
     <header>
       <h1>People</h1>

--- a/templates/person_detail.html
+++ b/templates/person_detail.html
@@ -217,7 +217,7 @@
     <nav>
       <a href="{{ url_for('upload_form') }}">Library</a>
       <a href="{{ url_for('people_page') }}" class="is-active">People</a>
-      <a href="#">Search</a>
+      <a href="{{ url_for('search_page') }}">Search</a>
     </nav>
     <a class="back" href="{{ url_for('people_page') }}">&larr; People</a>
     <header>

--- a/templates/person_form.html
+++ b/templates/person_form.html
@@ -195,7 +195,7 @@
     <nav>
       <a href="{{ url_for('upload_form') }}">Library</a>
       <a href="{{ url_for('people_page') }}">People</a>
-      <a href="#">Search</a>
+      <a href="{{ url_for('search_page') }}">Search</a>
     </nav>
     <header>
       <h1>{{ 'Edit' if person else 'New' }} Person</h1>

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,0 +1,289 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="theme-color" content="#0f1419">
+  <title>Search</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0f1419;
+      --bg-elevated: #1a2332;
+      --bg-input: #243044;
+      --border: #2d3a4d;
+      --text: #e7ecf3;
+      --text-muted: #8b9aad;
+      --accent: #5b9fd4;
+      --accent-hover: #7eb6e8;
+      --radius: 12px;
+      --tap-min: 44px;
+      --font: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+    }
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100dvh;
+      font-family: var(--font);
+      font-size: 1rem;
+      line-height: 1.5;
+      color: var(--text);
+      background: var(--bg);
+      -webkit-font-smoothing: antialiased;
+      padding:
+        max(1rem, env(safe-area-inset-top))
+        max(1rem, env(safe-area-inset-right))
+        max(1.25rem, env(safe-area-inset-bottom))
+        max(1rem, env(safe-area-inset-left));
+    }
+    .wrap { width: 100%; max-width: 28rem; margin: 0 auto; }
+    nav {
+      display: flex;
+      gap: 0;
+      margin-bottom: 1.5rem;
+      border: 1px solid var(--border);
+      border-radius: calc(var(--radius) - 4px);
+      overflow: hidden;
+    }
+    nav a {
+      flex: 1;
+      text-align: center;
+      padding: 0.65rem 0.5rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      text-decoration: none;
+      background: var(--bg-input);
+    }
+    nav a.is-active {
+      color: var(--text);
+      background: var(--bg-elevated);
+      box-shadow: inset 0 -2px 0 0 var(--accent);
+    }
+    nav a + a { border-left: 1px solid var(--border); }
+    nav a:hover:not(.is-active) { color: var(--text); }
+    h1 {
+      font-size: clamp(1.35rem, 4vw, 1.6rem);
+      font-weight: 600;
+      letter-spacing: -0.02em;
+      margin: 0 0 0.35rem;
+    }
+    .lede {
+      margin: 0 0 1.25rem;
+      font-size: 0.9rem;
+      color: var(--text-muted);
+    }
+    .search-form {
+      display: flex;
+      gap: 0.5rem;
+      margin-bottom: 1.5rem;
+    }
+    .search-form input[type="text"] {
+      flex: 1;
+      min-height: var(--tap-min);
+      padding: 0.65rem 0.85rem;
+      font-size: 1rem;
+      font-family: inherit;
+      color: var(--text);
+      background: var(--bg-input);
+      border: 1px solid var(--border);
+      border-radius: calc(var(--radius) - 4px);
+      outline: none;
+    }
+    .search-form input[type="text"]:focus {
+      border-color: var(--accent);
+    }
+    .search-form input[type="text"]::placeholder {
+      color: var(--text-muted);
+    }
+    .search-form input[type="submit"] {
+      min-height: var(--tap-min);
+      padding: 0 1.1rem;
+      font-size: 1rem;
+      font-weight: 600;
+      font-family: inherit;
+      color: var(--bg);
+      background: var(--accent);
+      border: none;
+      border-radius: calc(var(--radius) - 4px);
+      cursor: pointer;
+    }
+    .search-form input[type="submit"]:hover {
+      background: var(--accent-hover);
+    }
+    .search-form input[type="submit"]:active {
+      transform: scale(0.98);
+    }
+    .mode-toggle {
+      display: flex;
+      gap: 0;
+      margin-bottom: 1rem;
+      border: 1px solid var(--border);
+      border-radius: calc(var(--radius) - 4px);
+      overflow: hidden;
+    }
+    .mode-toggle a {
+      flex: 1;
+      text-align: center;
+      padding: 0.55rem 0.65rem;
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      text-decoration: none;
+      background: var(--bg-input);
+    }
+    .mode-toggle a.is-active {
+      color: var(--text);
+      background: var(--bg-elevated);
+      box-shadow: inset 0 -2px 0 0 var(--accent);
+    }
+    .mode-toggle a + a { border-left: 1px solid var(--border); }
+    .mode-toggle a:hover:not(.is-active) { color: var(--text); }
+    h2 {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--text-muted);
+      margin: 0 0 0.75rem;
+    }
+    .thumb-grid {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0.75rem;
+    }
+    @media (min-width: 400px) {
+      .thumb-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    }
+    .thumb-card {
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+      background: var(--bg-input);
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+    }
+    .thumb-preview {
+      display: block;
+      aspect-ratio: 1;
+      background: #0a0e14;
+      position: relative;
+    }
+    .thumb-preview img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+    .thumb-placeholder {
+      width: 100%;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.7rem;
+      font-weight: 700;
+      color: var(--text-muted);
+      letter-spacing: 0.06em;
+    }
+    .thumb-meta {
+      padding: 0.45rem 0.5rem 0.5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+      flex: 1;
+    }
+    .thumb-name {
+      font-size: 0.72rem;
+      color: var(--accent);
+      word-break: break-word;
+      text-decoration: none;
+      line-height: 1.25;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+    .thumb-name:hover { color: var(--accent-hover); }
+    .thumb-reason {
+      font-size: 0.68rem;
+      color: var(--text-muted);
+      word-break: break-word;
+      line-height: 1.3;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+    .empty {
+      margin: 0;
+      padding: 1.5rem 1rem;
+      text-align: center;
+      font-size: 0.9rem;
+      color: var(--text-muted);
+      border: 1px dashed var(--border);
+      border-radius: calc(var(--radius) - 4px);
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <nav>
+      <a href="{{ url_for('upload_form') }}">Library</a>
+      <a href="{{ url_for('people_page') }}">People</a>
+      <a href="{{ url_for('search_page') }}" class="is-active">Search</a>
+    </nav>
+    <header>
+      <h1>Search</h1>
+      <p class="lede">Find photos by their metadata</p>
+    </header>
+    <form class="search-form" method="get" action="{{ url_for('search_page') }}">
+      <input type="text" name="q" value="{{ query | e if query else '' }}" placeholder="Search photos..." autocomplete="off">
+      <input type="hidden" name="mode" value="text">
+      <input type="submit" value="Search">
+    </form>
+    <div class="mode-toggle">
+      <a href="{{ url_for('search_page') }}?mode=text{% if query %}&q={{ query | urlencode }}{% endif %}" class="{% if mode != 'person' %}is-active{% endif %}">Text search</a>
+      <a href="{{ url_for('search_page') }}?mode=person{% if query %}&q={{ query | urlencode }}{% endif %}">Find person</a>
+    </div>
+    {% if query and mode != 'person' %}
+    <section aria-labelledby="results-heading">
+      <h2 id="results-heading">{{ results|length }} result{% if results|length != 1 %}s{% endif %}</h2>
+      {% if results %}
+      <ul class="thumb-grid">
+        {% for path, meta, match_reason in results %}
+        {% set filename = path.name %}
+        {% set parts = filename.rsplit('.', 1) %}
+        {% set ext = parts[1].lower() if parts|length == 2 else '' %}
+        {% set is_img = ext in ['png', 'jpg', 'jpeg', 'gif'] %}
+        <li>
+          <a class="thumb-card" href="{{ url_for('file_detail', filename=filename) }}">
+            <div class="thumb-preview">
+              {% if is_img %}
+              <img src="{{ url_for('uploaded_file', filename=filename) }}" alt="" loading="lazy" width="200" height="200">
+              {% else %}
+              <span class="thumb-placeholder"><span>{{ ext|upper if ext else 'FILE' }}</span></span>
+              {% endif %}
+            </div>
+            <div class="thumb-meta">
+              <span class="thumb-name">{{ filename }}</span>
+              {% if match_reason %}
+              <span class="thumb-reason">{{ match_reason }}</span>
+              {% endif %}
+            </div>
+          </a>
+        </li>
+        {% endfor %}
+      </ul>
+      {% else %}
+      <p class="empty">No photos matched query</p>
+      {% endif %}
+    </section>
+    {% endif %}
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `/search` page with text search across all sidecar metadata
- Uses existing `sidecar.search()` for case-insensitive matching
- Results displayed as thumbnail grid with match reason
- Mode toggle: Text search (active) | Find person (placeholder link)
- Update nav links across all templates

## Changes
- `app.py`: Add `search_page()` route with `_find_match_reason()` helper
- `templates/search.html`: New template with dark mobile-first styling
- All templates: Update nav Search links from `#` to `/search`