### PR TITLE
LM Studio status banner

### DIFF
--- a/app.py
+++ b/app.py
@@ -734,6 +734,16 @@ def lmstudio_status():
     return jsonify({"server": server, "model": model_state})
 
 
+@app.route("/api/lmstudio/start", methods=["POST"])
+def lmstudio_start():
+    base = os.environ.get("LMSTUDIO_BASE", "http://127.0.0.1:1234/v1")
+    model = os.environ.get("LMSTUDIO_MODEL", "")
+    if model:
+        t = threading.Thread(target=lambda: lmstudio.ensure_ready(base, model), daemon=True)
+        t.start()
+    return jsonify({"status": "starting"})
+
+
 def _start_lmstudio_background():
     base = os.environ.get("LMSTUDIO_BASE", "http://127.0.0.1:1234/v1")
     model = os.environ.get("LMSTUDIO_MODEL", "")

--- a/templates/confirm_grid.html
+++ b/templates/confirm_grid.html
@@ -310,6 +310,7 @@
       <a href="{{ url_for('people_page') }}">People</a>
       <a href="#" class="is-active">Confirm</a>
     </nav>
+    {% include 'lms_banner.html' %}
     <a class="back" href="{{ url_for('person_detail', person_id=person.id) }}">&larr; {{ person.name | e }}</a>
 
     {% if waiting %}

--- a/templates/detail.html
+++ b/templates/detail.html
@@ -182,6 +182,7 @@
       <a href="{{ url_for('people_page') }}">People</a>
       <a href="{{ url_for('search_page') }}">Search</a>
     </nav>
+    {% include 'lms_banner.html' %}
     <a class="back" href="{{ url_for('upload_form', view=view_mode) }}">← All files</a>
     <h1>{{ filename|e }}</h1>
 

--- a/templates/library.html
+++ b/templates/library.html
@@ -339,8 +339,9 @@
       <a href="{{ url_for('people_page') }}">People</a>
       <a href="{{ url_for('search_page') }}">Search</a>
     </nav>
+    {% include 'lms_banner.html' %}
     <header>
-      <h1>Upload files <span id="lms-status" style="display:inline-block;width:8px;height:8px;border-radius:50%;background:#f44336;vertical-align:middle;margin-left:6px;"></span></h1>
+      <h1>Upload files</h1>
       <p class="lede">txt, pdf, png, jpg, jpeg, gif — multiple files allowed</p>
     </header>
     <section class="card" aria-labelledby="upload-heading">
@@ -438,20 +439,6 @@
       es.onerror = function() { es.close(); };
       return es;
     }
-    (function() {
-      var dot = document.getElementById('lms-status');
-      if (!dot) return;
-      function poll() {
-        fetch('/api/lmstudio/status')
-          .then(function(r) { return r.json(); })
-          .then(function(d) {
-            dot.style.background = (d.server === 'up' && d.model === 'loaded') ? '#4caf50' : '#f44336';
-          })
-          .catch(function() { dot.style.background = '#f44336'; });
-      }
-      poll();
-      setInterval(poll, 5000);
-    })();
     (function() {
       var jobId = {{ describe_job_id|tojson }};
       if (!jobId) return;

--- a/templates/lms_banner.html
+++ b/templates/lms_banner.html
@@ -1,0 +1,123 @@
+<style>
+  #lms-banner {
+    margin: 0 0 1rem;
+    padding: 0.6rem 0.8rem;
+    border-radius: 8px;
+    font-size: 0.85rem;
+    line-height: 1.4;
+    display: none;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  #lms-banner.visible { display: flex; }
+  .lms-banner--ready { color: #c8e6c9; background: rgba(76, 175, 80, 0.15); border: 1px solid rgba(76, 175, 80, 0.45); }
+  .lms-banner--starting { color: #fff9c4; background: rgba(255, 193, 7, 0.15); border: 1px solid rgba(255, 193, 7, 0.45); }
+  .lms-banner--offline { color: #ffcdd2; background: rgba(229, 57, 53, 0.15); border: 1px solid rgba(229, 57, 53, 0.45); }
+  #lms-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #f44336;
+    flex-shrink: 0;
+  }
+  .lms-banner--ready #lms-dot { background: #4caf50; }
+  .lms-banner--starting #lms-dot { background: #ffc107; }
+  #lms-label { flex: 1; }
+  #lms-dismiss {
+    background: none;
+    border: none;
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+    padding: 0 0.25rem;
+    opacity: 0.7;
+  }
+  #lms-dismiss:hover { opacity: 1; }
+  #lms-start {
+    padding: 0.25rem 0.6rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    font-family: inherit;
+    color: #0f1419;
+    background: #ffc107;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  #lms-start:hover { background: #ffca28; }
+  #lms-start:disabled { opacity: 0.5; cursor: not-allowed; }
+</style>
+<div id="lms-banner" role="status" aria-live="polite">
+  <span id="lms-dot"></span>
+  <span id="lms-label">LM Studio offline</span>
+  <button id="lms-start" type="button">Start</button>
+  <button id="lms-dismiss" type="button" aria-label="Dismiss">&times;</button>
+</div>
+<script>
+(function() {
+  var banner = document.getElementById('lms-banner');
+  var dot = document.getElementById('lms-dot');
+  var label = document.getElementById('lms-label');
+  var startBtn = document.getElementById('lms-start');
+  var dismissBtn = document.getElementById('lms-dismiss');
+  var dismissed = false;
+
+  dismissBtn.addEventListener('click', function() {
+    dismissed = true;
+    banner.classList.remove('visible');
+  });
+
+  startBtn.addEventListener('click', function() {
+    startBtn.disabled = true;
+    fetch('/api/lmstudio/start', { method: 'POST' })
+      .then(function(r) { return r.json(); })
+      .then(function(d) {
+        if (d.status === 'starting') {
+          setStatus('starting');
+        }
+      })
+      .catch(function() {
+        startBtn.disabled = false;
+      });
+  });
+
+  function setStatus(state) {
+    banner.classList.remove('visible', 'lms-banner--ready', 'lms-banner--starting', 'lms-banner--offline');
+    if (state === 'ready') {
+      banner.classList.add('visible', 'lms-banner--ready');
+      label.textContent = 'LM Studio ready';
+      startBtn.style.display = 'none';
+    } else if (state === 'starting') {
+      banner.classList.add('visible', 'lms-banner--starting');
+      label.textContent = 'LM Studio starting...';
+      startBtn.style.display = 'none';
+    } else {
+      banner.classList.add('visible', 'lms-banner--offline');
+      label.textContent = 'LM Studio offline';
+      startBtn.style.display = 'inline-block';
+      startBtn.disabled = false;
+    }
+  }
+
+  function poll() {
+    fetch('/api/lmstudio/status')
+      .then(function(r) { return r.json(); })
+      .then(function(d) {
+        if (d.server === 'up' && d.model === 'loaded') {
+          setStatus('ready');
+        } else if (d.server === 'up') {
+          setStatus('starting');
+        } else {
+          setStatus('offline');
+        }
+      })
+      .catch(function() {
+        setStatus('offline');
+      });
+  }
+
+  poll();
+  setInterval(poll, 5000);
+})();
+</script>

--- a/templates/people.html
+++ b/templates/people.html
@@ -178,6 +178,7 @@
       <a href="{{ url_for('people_page') }}" class="is-active">People</a>
       <a href="{{ url_for('search_page') }}">Search</a>
     </nav>
+    {% include 'lms_banner.html' %}
     <header>
       <h1>People</h1>
       <p class="lede">Known people in your photo library</p>

--- a/templates/person_detail.html
+++ b/templates/person_detail.html
@@ -219,6 +219,7 @@
       <a href="{{ url_for('people_page') }}" class="is-active">People</a>
       <a href="{{ url_for('search_page') }}">Search</a>
     </nav>
+    {% include 'lms_banner.html' %}
     <a class="back" href="{{ url_for('people_page') }}">&larr; People</a>
     <header>
       <h1>{{ person.name | e }}</h1>

--- a/templates/person_form.html
+++ b/templates/person_form.html
@@ -197,6 +197,7 @@
       <a href="{{ url_for('people_page') }}">People</a>
       <a href="{{ url_for('search_page') }}">Search</a>
     </nav>
+    {% include 'lms_banner.html' %}
     <header>
       <h1>{{ 'Edit' if person else 'New' }} Person</h1>
       <p class="lede">{{ "Update name or add photos." if person else "Add a reference name and photos." }}</p>

--- a/templates/search.html
+++ b/templates/search.html
@@ -329,6 +329,7 @@
       <a href="{{ url_for('people_page') }}">People</a>
       <a href="{{ url_for('search_page') }}" class="is-active">Search</a>
     </nav>
+    {% include 'lms_banner.html' %}
     <header>
       <h1>Search</h1>
       <p class="lede">Find photos by their metadata</p>


### PR DESCRIPTION
## Summary
- Creates `templates/lms_banner.html` with a status banner (dot + text label + dismissible + Start button)
- Adds `POST /api/lmstudio/start` endpoint to `app.py` that queues `lmstudio.ensure_ready()` in a background thread
- Replaces the inline dot in `library.html` with `{% include 'lms_banner.html' %}` in all 7 templates
- Banner auto-dismisses when polling sees status turn green