### PR TITLE
Wire confirmation engine into existing templates (closes #36)

### DIFF
--- a/app.py
+++ b/app.py
@@ -507,11 +507,14 @@ def person_detail(person_id):
     tagged_results = sidecar.search(Path(UPLOAD_FOLDER), person.get("name", ""))
     tagged_photos = [(path, meta) for path, meta in tagged_results]
 
+    lms_connected = lmstudio.server_is_up()
+
     return render_template(
         "person_detail.html",
         person=person,
         tagged_photos=tagged_photos,
         tagged_count=len(tagged_photos),
+        lms_connected=lms_connected,
     )
 
 

--- a/app.py
+++ b/app.py
@@ -578,6 +578,15 @@ def confirm_person(person_id):
             })
 
         walkthrough = request.args.get("walkthrough") == "1"
+
+        confidence_scores = {}
+        confirm_data = confirmations.read_confirmations(person_id)
+        for fname, photo in confirm_data.get("photos", {}).items():
+            confidence_scores[fname] = {
+                "confidence": photo.get("confidence", 0.0),
+                "votes": photo.get("yes_votes", 0) + photo.get("no_votes", 0),
+            }
+
         return render_template(
             "confirm_grid.html",
             person=person,
@@ -585,6 +594,7 @@ def confirm_person(person_id):
             matches=matches,
             no_match=no_match,
             walkthrough=walkthrough,
+            confidence_scores=confidence_scores,
         )
 
     confirmed_filenames = request.form.getlist("confirmed")

--- a/templates/confirm_grid.html
+++ b/templates/confirm_grid.html
@@ -187,6 +187,12 @@
       margin-top: 0.25rem;
       line-height: 1.4;
     }
+    .card-badge {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      margin-top: 0.25rem;
+      opacity: 0.85;
+    }
     .btn {
       min-height: var(--tap-min);
       padding: 0 1.1rem;
@@ -382,6 +388,9 @@
             <div class="card-body">
               <div class="card-filename">{{ item.filename }}</div>
               <div class="card-reason">{{ item.reason }}</div>
+              {% if confidence_scores.get(item.filename) %}
+              <div class="card-badge">{{ (confidence_scores[item.filename].confidence * 100) | round | int }}% ({{ confidence_scores[item.filename].votes }} votes)</div>
+              {% endif %}
             </div>
           </div>
           {% endfor %}
@@ -408,6 +417,9 @@
               <div class="card-body">
                 <div class="card-filename">{{ item.filename }}</div>
                 <div class="card-reason">{{ item.reason }}</div>
+                {% if confidence_scores.get(item.filename) %}
+                <div class="card-badge">{{ (confidence_scores[item.filename].confidence * 100) | round | int }}% ({{ confidence_scores[item.filename].votes }} votes)</div>
+                {% endif %}
               </div>
             </div>
             {% endfor %}

--- a/templates/detail.html
+++ b/templates/detail.html
@@ -173,6 +173,25 @@
     }
     nav a + a { border-left: 1px solid var(--border); }
     nav a:hover:not(.is-active) { color: var(--text); }
+    .conf-score-person {
+      display: flex;
+      justify-content: space-between;
+      margin-bottom: 0.35rem;
+      font-size: 0.8rem;
+      color: var(--text-muted);
+    }
+    .confidence-bar {
+      height: 0.5rem;
+      background: var(--bg-input);
+      border-radius: calc(var(--radius) - 4px);
+      overflow: hidden;
+    }
+    .confidence-fill {
+      height: 100%;
+      background: var(--accent);
+      border-radius: calc(var(--radius) - 4px);
+      transition: width 0.3s ease;
+    }
   </style>
 </head>
 <body>
@@ -236,6 +255,23 @@
         <dd><code>{{ lmstudio_meta.model|e }}</code></dd>
         {% endif %}
       </dl>
+    </div>
+    {% endif %}
+
+    {% if lmstudio_meta.get('confirmation_scores') %}
+    <div class="card">
+      <h2>Confirmation Scores</h2>
+      {% for person_name, data in lmstudio_meta.confirmation_scores.items() %}
+      <div style="margin-bottom:0.75rem">
+        <div class="conf-score-person">
+          <span>{{ person_name | e }}</span>
+          <span>{{ (data.confidence * 100) | round | int }}% ({{ data.votes }} votes)</span>
+        </div>
+        <div class="confidence-bar">
+          <div class="confidence-fill" style="width: {{ data.confidence * 100 }}%"></div>
+        </div>
+      </div>
+      {% endfor %}
     </div>
     {% endif %}
 

--- a/templates/person_detail.html
+++ b/templates/person_detail.html
@@ -230,7 +230,9 @@
           <button class="btn btn-danger" type="submit" onclick="return confirm('Delete this person?')">Delete</button>
         </form>
         <button class="btn btn-secondary" id="find-btn" onclick="findInLibrary()">Find in library</button>
+        <button class="btn btn-secondary" id="confirm-btn" onclick="startInteractiveConfirm()">Confirm photos (interactive)</button>
       </div>
+      <div id="lms-warning" class="banner" style="display:none;margin-top:0.5rem;padding:0.5rem 0.75rem;font-size:0.85rem;color:var(--text-muted);background:rgba(139,154,173,0.12);border:1px solid rgba(139,154,173,0.35);border-radius:calc(var(--radius)-4px);">LM Studio not connected — AI hints will be unavailable, but you can still confirm manually.</div>
     </header>
 
     <div class="section">
@@ -268,6 +270,10 @@
     </div>
   </div>
   <script>
+    var lmsConnected = {{ 'true' if lms_connected else 'false' }};
+    if (!lmsConnected && document.getElementById('lms-warning')) {
+      document.getElementById('lms-warning').style.display = 'block';
+    }
     function findInLibrary() {
       var btn = document.getElementById('find-btn');
       btn.disabled = true;
@@ -286,6 +292,27 @@
         .catch(function(err) {
           btn.disabled = false;
           btn.textContent = 'Find in library';
+          alert('Error: ' + err);
+        });
+    }
+    function startInteractiveConfirm() {
+      var btn = document.getElementById('confirm-btn');
+      btn.disabled = true;
+      btn.textContent = 'Starting…';
+      fetch('{{ url_for("create_confirm_session", person_id=person.id) }}', {method: 'POST'})
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+          if (data.session_id) {
+            window.location.href = '/people/{{ person.id }}/interactive-confirm?session=' + data.session_id;
+          } else {
+            btn.disabled = false;
+            btn.textContent = 'Confirm photos (interactive)';
+            alert('Failed to start session: ' + JSON.stringify(data));
+          }
+        })
+        .catch(function(err) {
+          btn.disabled = false;
+          btn.textContent = 'Confirm photos (interactive)';
           alert('Error: ' + err);
         });
     }

--- a/templates/relationship_report.html
+++ b/templates/relationship_report.html
@@ -89,7 +89,7 @@
     }
     .stats {
       display: grid;
-      grid-template-columns: 1fr 1fr 1fr;
+      grid-template-columns: 1fr 1fr;
       gap: 0.75rem;
       margin-bottom: 1.5rem;
     }
@@ -119,38 +119,6 @@
       text-transform: uppercase;
       letter-spacing: 0.05em;
     }
-    .filter {
-      display: flex;
-      gap: 0.5rem;
-      margin-bottom: 1rem;
-    }
-    .filter-btn {
-      padding: 0.4rem 0.75rem;
-      font-size: 0.8rem;
-      font-weight: 600;
-      font-family: inherit;
-      color: var(--text-muted);
-      background: var(--bg-input);
-      border: 1px solid var(--border);
-      border-radius: calc(var(--radius) - 4px);
-      cursor: pointer;
-    }
-    .filter-btn.is-active {
-      color: var(--text);
-      background: var(--bg-elevated);
-      border-color: var(--accent);
-    }
-    .filter-btn:hover:not(.is-active) { color: var(--text); }
-    .download-link {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.35rem;
-      margin-top: 1.5rem;
-      font-size: 0.85rem;
-      color: var(--accent);
-      text-decoration: none;
-    }
-    .download-link:hover { color: var(--accent-hover); text-decoration: underline; }
     .photos-list {
       display: flex;
       flex-direction: column;
@@ -205,9 +173,6 @@
     }
     .photo-item.confirmed {
       border-color: var(--success);
-    }
-    .photo-item:not(.confirmed) {
-      opacity: 0.6;
     }
     .photo-item.confirmed .photo-confidence-fill {
       background: var(--success);
@@ -279,29 +244,19 @@
         <div class="stat-value">{{ report.total_photos }}</div>
         <div class="stat-label">Reviewed</div>
       </div>
-      <div class="stat">
-        <div class="stat-value">{{ (report.confirmed_count / report.total_photos * 100) | int if report.total_photos > 0 else 0 }}%</div>
-        <div class="stat-label">Rate</div>
-      </div>
     </div>
 
     <a class="btn" href="{{ url_for('interactive_confirm', person_id=person.id) }}">Continue Confirming</a>
 
     <div style="margin-top: 1.5rem">
-      <div class="filter">
-        <button class="filter-btn is-active" data-filter="all">All</button>
-        <button class="filter-btn" data-filter="confirmed">Confirmed only</button>
-      </div>
       <h2 class="section-title">All Reviewed Photos</h2>
       {% if report.photos %}
       <div class="photos-list">
         {% for photo in report.photos %}
-        <div class="photo-item {% if photo.confirmed %}confirmed{% endif %}" data-confirmed="{{ 'true' if photo.confirmed else 'false' }}">
-          <a href="{{ url_for('file_detail', filename=photo.filename) }}">
-            <div class="photo-thumb">
-              <img src="{{ url_for('uploaded_file', filename=photo.filename) }}" alt="" loading="lazy">
-            </div>
-          </a>
+        <div class="photo-item {% if photo.confirmed %}confirmed{% endif %}">
+          <div class="photo-thumb">
+            <img src="{{ url_for('uploaded_file', filename=photo.filename) }}" alt="" loading="lazy">
+          </div>
           <div class="photo-info">
             <div class="photo-name">
               {{ photo.filename }}
@@ -318,25 +273,7 @@
       {% else %}
       <div class="empty">No photos reviewed yet</div>
       {% endif %}
-      <a class="download-link" href="{{ url_for('relationship_map', person_id=person.id) }}">Download JSON</a>
     </div>
-
-    <script>
-      (function() {
-        var btns = document.querySelectorAll('.filter-btn');
-        var items = document.querySelectorAll('.photo-item');
-        btns.forEach(function(btn) {
-          btn.addEventListener('click', function() {
-            btns.forEach(function(b) { b.classList.remove('is-active'); });
-            btn.classList.add('is-active');
-            var filter = btn.dataset.filter;
-            items.forEach(function(item) {
-              item.style.display = (filter === 'confirmed' && item.dataset.confirmed !== 'true') ? 'none' : '';
-            });
-          });
-        });
-      })();
-    </script>
   </div>
 </body>
 </html>

--- a/templates/relationship_report.html
+++ b/templates/relationship_report.html
@@ -89,7 +89,7 @@
     }
     .stats {
       display: grid;
-      grid-template-columns: 1fr 1fr;
+      grid-template-columns: 1fr 1fr 1fr;
       gap: 0.75rem;
       margin-bottom: 1.5rem;
     }
@@ -119,6 +119,38 @@
       text-transform: uppercase;
       letter-spacing: 0.05em;
     }
+    .filter {
+      display: flex;
+      gap: 0.5rem;
+      margin-bottom: 1rem;
+    }
+    .filter-btn {
+      padding: 0.4rem 0.75rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      font-family: inherit;
+      color: var(--text-muted);
+      background: var(--bg-input);
+      border: 1px solid var(--border);
+      border-radius: calc(var(--radius) - 4px);
+      cursor: pointer;
+    }
+    .filter-btn.is-active {
+      color: var(--text);
+      background: var(--bg-elevated);
+      border-color: var(--accent);
+    }
+    .filter-btn:hover:not(.is-active) { color: var(--text); }
+    .download-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      margin-top: 1.5rem;
+      font-size: 0.85rem;
+      color: var(--accent);
+      text-decoration: none;
+    }
+    .download-link:hover { color: var(--accent-hover); text-decoration: underline; }
     .photos-list {
       display: flex;
       flex-direction: column;
@@ -173,6 +205,9 @@
     }
     .photo-item.confirmed {
       border-color: var(--success);
+    }
+    .photo-item:not(.confirmed) {
+      opacity: 0.6;
     }
     .photo-item.confirmed .photo-confidence-fill {
       background: var(--success);
@@ -244,19 +279,29 @@
         <div class="stat-value">{{ report.total_photos }}</div>
         <div class="stat-label">Reviewed</div>
       </div>
+      <div class="stat">
+        <div class="stat-value">{{ (report.confirmed_count / report.total_photos * 100) | int if report.total_photos > 0 else 0 }}%</div>
+        <div class="stat-label">Rate</div>
+      </div>
     </div>
 
     <a class="btn" href="{{ url_for('interactive_confirm', person_id=person.id) }}">Continue Confirming</a>
 
     <div style="margin-top: 1.5rem">
+      <div class="filter">
+        <button class="filter-btn is-active" data-filter="all">All</button>
+        <button class="filter-btn" data-filter="confirmed">Confirmed only</button>
+      </div>
       <h2 class="section-title">All Reviewed Photos</h2>
       {% if report.photos %}
       <div class="photos-list">
         {% for photo in report.photos %}
-        <div class="photo-item {% if photo.confirmed %}confirmed{% endif %}">
-          <div class="photo-thumb">
-            <img src="{{ url_for('uploaded_file', filename=photo.filename) }}" alt="" loading="lazy">
-          </div>
+        <div class="photo-item {% if photo.confirmed %}confirmed{% endif %}" data-confirmed="{{ 'true' if photo.confirmed else 'false' }}">
+          <a href="{{ url_for('file_detail', filename=photo.filename) }}">
+            <div class="photo-thumb">
+              <img src="{{ url_for('uploaded_file', filename=photo.filename) }}" alt="" loading="lazy">
+            </div>
+          </a>
           <div class="photo-info">
             <div class="photo-name">
               {{ photo.filename }}
@@ -273,7 +318,25 @@
       {% else %}
       <div class="empty">No photos reviewed yet</div>
       {% endif %}
+      <a class="download-link" href="{{ url_for('relationship_map', person_id=person.id) }}">Download JSON</a>
     </div>
+
+    <script>
+      (function() {
+        var btns = document.querySelectorAll('.filter-btn');
+        var items = document.querySelectorAll('.photo-item');
+        btns.forEach(function(btn) {
+          btn.addEventListener('click', function() {
+            btns.forEach(function(b) { b.classList.remove('is-active'); });
+            btn.classList.add('is-active');
+            var filter = btn.dataset.filter;
+            items.forEach(function(item) {
+              item.style.display = (filter === 'confirmed' && item.dataset.confirmed !== 'true') ? 'none' : '';
+            });
+          });
+        });
+      })();
+    </script>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Added "Confirm photos (interactive)" button to person_detail.html that starts a session and redirects to interactive confirm UI
- Added LM Studio connection warning (non-blocking) when LM Studio is not connected
- Added confidence badges to confirm_grid.html showing percentage and votes for photos with confirmation history
- Added "Confirmation Scores" section to detail.html displaying per-person confidence bars when score data exists

## Testing
- The button makes a POST to `/api/people/<pid>/confirm-session` and redirects to `/people/<pid>/interactive-confirm?session=<session_id>`
- Confidence badges only appear when confirmation data exists (no empty placeholder)
- Confirmation Scores section only renders when `lm_raw.confirmation_scores` is present and non-empty