### PR TITLE
Fix: Always start LMStudio server regardless of LMSTUDIO_MODEL value

### DIFF
--- a/app.py
+++ b/app.py
@@ -1026,18 +1026,16 @@ def lmstudio_status():
 def lmstudio_start():
     base = os.environ.get("LMSTUDIO_BASE", "http://127.0.0.1:1234/v1")
     model = os.environ.get("LMSTUDIO_MODEL", "")
-    if model:
-        t = threading.Thread(target=lambda: lmstudio.ensure_ready(base, model), daemon=True)
-        t.start()
+    t = threading.Thread(target=lambda: lmstudio.ensure_ready(base, model), daemon=True)
+    t.start()
     return jsonify({"status": "starting"})
 
 
 def _start_lmstudio_background():
     base = os.environ.get("LMSTUDIO_BASE", "http://127.0.0.1:1234/v1")
     model = os.environ.get("LMSTUDIO_MODEL", "")
-    if model:
-        t = threading.Thread(target=lambda: lmstudio.ensure_ready(base, model), daemon=True)
-        t.start()
+    t = threading.Thread(target=lambda: lmstudio.ensure_ready(base, model), daemon=True)
+    t.start()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Removes the `if model:` guard that prevented the background thread from starting when `LMSTUDIO_MODEL` is unset or empty
- `ensure_ready()` already handles the no-model case gracefully (starts server, skips load)
- Applies to both `/api/lmstudio/start` endpoint and `_start_lmstudio_background()` on app startup

Closes #47