### PR TITLE
Add model picker dropdown to LM Studio banner (closes #49)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1019,16 +1019,36 @@ def lmstudio_status():
     model_state = "unloaded"
     if server == "up" and model:
         model_state = "loaded" if lmstudio.model_is_loaded(base, model) else "unloaded"
-    return jsonify({"server": server, "model": model_state})
+    available_models = []
+    if server == "up":
+        available_models = lmstudio.get_available_models(base)
+    return jsonify({
+        "server": server,
+        "model": model_state,
+        "model_configured": model,
+        "available_models": available_models,
+    })
+
+
+@app.route("/api/lmstudio/models")
+def lmstudio_models():
+    base = os.environ.get("LMSTUDIO_BASE", "http://127.0.0.1:1234/v1")
+    if not lmstudio.server_is_up(base):
+        return jsonify({"models": []})
+    models = lmstudio.get_available_models(base)
+    return jsonify({"models": models})
 
 
 @app.route("/api/lmstudio/start", methods=["POST"])
 def lmstudio_start():
     base = os.environ.get("LMSTUDIO_BASE", "http://127.0.0.1:1234/v1")
     model = os.environ.get("LMSTUDIO_MODEL", "")
+    data = request.get_json() or {}
+    if data.get("model"):
+        model = data["model"]
     t = threading.Thread(target=lambda: lmstudio.ensure_ready(base, model), daemon=True)
     t.start()
-    return jsonify({"status": "starting"})
+    return jsonify({"status": "starting", "model": model})
 
 
 def _start_lmstudio_background():

--- a/services/lmstudio.py
+++ b/services/lmstudio.py
@@ -100,6 +100,15 @@ def model_is_loaded(base_url: str = LMSTUDIO_BASE, model: str = LMSTUDIO_MODEL) 
         return False
 
 
+def get_available_models(base_url: str = LMSTUDIO_BASE) -> list[str]:
+    try:
+        with urllib.request.urlopen(base_url.rstrip("/") + "/models", timeout=5) as r:
+            data = json.loads(r.read())
+        return [m.get("id") for m in data.get("data", []) if m.get("id")]
+    except Exception:
+        return []
+
+
 def _run_lms(*args: str) -> bool:
     try:
         result = subprocess.run([LMS, *args])

--- a/templates/lms_banner.html
+++ b/templates/lms_banner.html
@@ -24,6 +24,15 @@
   .lms-banner--ready #lms-dot { background: #4caf50; }
   .lms-banner--starting #lms-dot { background: #ffc107; }
   #lms-label { flex: 1; }
+  #lms-model-select {
+    font-size: 0.8rem;
+    padding: 0.2rem 0.4rem;
+    border-radius: 4px;
+    border: 1px solid #888;
+    background: #fff;
+    color: #333;
+  }
+  #lms-model-select:disabled { opacity: 0.6; }
   #lms-dismiss {
     background: none;
     border: none;
@@ -51,6 +60,7 @@
 <div id="lms-banner" role="status" aria-live="polite">
   <span id="lms-dot"></span>
   <span id="lms-label">LM Studio offline</span>
+  <select id="lms-model-select" style="display: none;"></select>
   <button id="lms-start" type="button">Start</button>
   <button id="lms-dismiss" type="button" aria-label="Dismiss">&times;</button>
 </div>
@@ -59,9 +69,12 @@
   var banner = document.getElementById('lms-banner');
   var dot = document.getElementById('lms-dot');
   var label = document.getElementById('lms-label');
+  var modelSelect = document.getElementById('lms-model-select');
   var startBtn = document.getElementById('lms-start');
   var dismissBtn = document.getElementById('lms-dismiss');
   var dismissed = false;
+  var currentModel = null;
+  var configuredModel = null;
 
   dismissBtn.addEventListener('click', function() {
     dismissed = true;
@@ -69,11 +82,17 @@
   });
 
   startBtn.addEventListener('click', function() {
+    var selectedModel = modelSelect.value;
     startBtn.disabled = true;
-    fetch('/api/lmstudio/start', { method: 'POST' })
+    fetch('/api/lmstudio/start', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({model: selectedModel || configuredModel})
+    })
       .then(function(r) { return r.json(); })
       .then(function(d) {
         if (d.status === 'starting') {
+          currentModel = d.model || selectedModel || configuredModel;
           setStatus('starting');
         }
       })
@@ -100,10 +119,34 @@
     }
   }
 
+  function populateModels(models) {
+    modelSelect.innerHTML = '';
+    if (!models || models.length === 0) {
+      modelSelect.style.display = 'none';
+      return;
+    }
+    modelSelect.style.display = 'inline-block';
+    var defaultOpt = document.createElement('option');
+    defaultOpt.value = '';
+    defaultOpt.textContent = 'Select model...';
+    modelSelect.appendChild(defaultOpt);
+    for (var i = 0; i < models.length; i++) {
+      var opt = document.createElement('option');
+      opt.value = models[i];
+      opt.textContent = models[i];
+      if (configuredModel && models[i] === configuredModel) {
+        opt.selected = true;
+      }
+      modelSelect.appendChild(opt);
+    }
+  }
+
   function poll() {
     fetch('/api/lmstudio/status')
       .then(function(r) { return r.json(); })
       .then(function(d) {
+        configuredModel = d.model_configured || null;
+        populateModels(d.available_models || []);
         if (d.server === 'up' && d.model === 'loaded') {
           setStatus('ready');
         } else if (d.server === 'up') {


### PR DESCRIPTION
## Summary
- Added `get_available_models()` function in `services/lmstudio.py` to query LM Studio's `/v1/models` endpoint
- Extended `/api/lmstudio/status` to return `available_models` list and `model_configured` (from `LMSTUDIO_MODEL` env var)
- Added new `/api/lmstudio/models` endpoint for listing available models
- Modified `/api/lmstudio/start` to accept optional `model` in request body, falling back to `LMSTUDIO_MODEL` env var
- Updated banner UI to show model dropdown when server is up and models are available
- Pre-selects model if `LMSTUDIO_MODEL` env var is set

## Acceptance criteria
- [x] New endpoint returns list of model IDs available in LM Studio (`/api/lmstudio/models`)
- [x] Banner shows model dropdown when server is up
- [x] Clicking Start with a selected model loads that model
- [x] Falls back gracefully when no models available (empty list, no dropdown shown)
- [x] `LMSTUDIO_MODEL` env var pre-selects model if set