### PR TITLE
Fix: launch ollama serve as background process

### DIFF
--- a/services/lmstudio.py
+++ b/services/lmstudio.py
@@ -126,7 +126,15 @@ def _run_cmd(*args: str) -> bool:
 
 def _start_server() -> bool:
     if LMSTUDIO_BACKEND == "ollama":
-        return _run_cmd("ollama", "serve")
+        try:
+            subprocess.Popen(
+                ["ollama", "serve"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return True
+        except FileNotFoundError:
+            return False
     return _run_cmd("lms", "server", "start")
 
 


### PR DESCRIPTION
## Summary
- Use `subprocess.Popen` instead of `subprocess.run` to launch `ollama serve` in background
- Returns immediately so the existing polling loop in `ensure_ready` can confirm the server is up
- `lms server start` behavior unchanged

closes #55