### PR TITLE
Fix: use lmstudio.LMSTUDIO_BASE for backend-aware default port

### DIFF
--- a/app.py
+++ b/app.py
@@ -297,7 +297,7 @@ def upload_file():
             images_needing_desc.append(str(fpath))
 
     if images_needing_desc:
-        base_url = os.environ.get("LMSTUDIO_BASE", "http://127.0.0.1:1234/v1")
+        base_url = lmstudio.LMSTUDIO_BASE
         model = os.environ.get("LMSTUDIO_MODEL", "")
         api_key = os.environ.get("LMSTUDIO_API_KEY", "lm-studio")
         if model:
@@ -994,7 +994,7 @@ def find_person_in_library(person_id):
     if not os.path.isfile(person_file):
         abort(404)
 
-    base_url = os.environ.get("LMSTUDIO_BASE", "http://127.0.0.1:1234/v1")
+    base_url = lmstudio.LMSTUDIO_BASE
     model = os.environ.get("LMSTUDIO_MODEL", "")
     api_key = os.environ.get("LMSTUDIO_API_KEY", "lm-studio")
 
@@ -1013,7 +1013,7 @@ def find_person_in_library(person_id):
 
 @app.route("/api/lmstudio/status")
 def lmstudio_status():
-    base = os.environ.get("LMSTUDIO_BASE", "http://127.0.0.1:1234/v1")
+    base = lmstudio.LMSTUDIO_BASE
     model = os.environ.get("LMSTUDIO_MODEL", "")
     server = "up" if lmstudio.server_is_up(base) else "down"
     model_state = "unloaded"
@@ -1032,7 +1032,7 @@ def lmstudio_status():
 
 @app.route("/api/lmstudio/models")
 def lmstudio_models():
-    base = os.environ.get("LMSTUDIO_BASE", "http://127.0.0.1:1234/v1")
+    base = lmstudio.LMSTUDIO_BASE
     if not lmstudio.server_is_up(base):
         return jsonify({"models": []})
     models = lmstudio.get_available_models(base)
@@ -1041,7 +1041,7 @@ def lmstudio_models():
 
 @app.route("/api/lmstudio/start", methods=["POST"])
 def lmstudio_start():
-    base = os.environ.get("LMSTUDIO_BASE", "http://127.0.0.1:1234/v1")
+    base = lmstudio.LMSTUDIO_BASE
     model = os.environ.get("LMSTUDIO_MODEL", "")
     data = request.get_json() or {}
     if data.get("model"):
@@ -1052,7 +1052,7 @@ def lmstudio_start():
 
 
 def _start_lmstudio_background():
-    base = os.environ.get("LMSTUDIO_BASE", "http://127.0.0.1:1234/v1")
+    base = lmstudio.LMSTUDIO_BASE
     model = os.environ.get("LMSTUDIO_MODEL", "")
     t = threading.Thread(target=lambda: lmstudio.ensure_ready(base, model), daemon=True)
     t.start()

--- a/services/lmstudio.py
+++ b/services/lmstudio.py
@@ -126,7 +126,15 @@ def _run_cmd(*args: str) -> bool:
 
 def _start_server() -> bool:
     if LMSTUDIO_BACKEND == "ollama":
-        return _run_cmd("ollama", "serve")
+        try:
+            subprocess.Popen(
+                ["ollama", "serve"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return True
+        except FileNotFoundError:
+            return False
     return _run_cmd("lms", "server", "start")
 
 

--- a/services/lmstudio.py
+++ b/services/lmstudio.py
@@ -99,6 +99,14 @@ def server_is_up(base_url: str = LMSTUDIO_BASE) -> bool:
 def model_is_loaded(base_url: str = LMSTUDIO_BASE, model: str = LMSTUDIO_MODEL) -> bool:
     if not model:
         return False
+    if LMSTUDIO_BACKEND == "ollama":
+        ollama_base = base_url.rsplit("/v1", 1)[0]
+        try:
+            with urllib.request.urlopen(ollama_base + "/api/tags", timeout=5) as r:
+                data = json.loads(r.read())
+            return any(m.get("name") == model for m in data.get("models", []))
+        except Exception:
+            return False
     try:
         with urllib.request.urlopen(base_url.rstrip("/") + "/models", timeout=5) as r:
             data = json.loads(r.read())
@@ -108,6 +116,14 @@ def model_is_loaded(base_url: str = LMSTUDIO_BASE, model: str = LMSTUDIO_MODEL) 
 
 
 def get_available_models(base_url: str = LMSTUDIO_BASE) -> list[str]:
+    if LMSTUDIO_BACKEND == "ollama":
+        ollama_base = base_url.rsplit("/v1", 1)[0]
+        try:
+            with urllib.request.urlopen(ollama_base + "/api/tags", timeout=5) as r:
+                data = json.loads(r.read())
+            return [m.get("name") for m in data.get("models", []) if m.get("name")]
+        except Exception:
+            return []
     try:
         with urllib.request.urlopen(base_url.rstrip("/") + "/models", timeout=5) as r:
             data = json.loads(r.read())


### PR DESCRIPTION
## Summary
- Replaces 6 hardcoded `os.environ.get("LMSTUDIO_BASE", "http://127.0.0.1:1234/v1")` fallbacks with `lmstudio.LMSTUDIO_BASE`
- Now correctly defaults to port 11434 for Ollama backend, port 1234 for LM Studio
- `LMSTUDIO_BASE` env var override still works as before

closes #59