### PR TITLE
Fix 404 by returning empty dict from load_lmstudio_sidecar

### DIFF
--- a/app.py
+++ b/app.py
@@ -80,8 +80,8 @@ def list_upload_folder():
 
 
 def load_lmstudio_sidecar(upload_path: Path):
-    """Read `imagename.meta.json` written by analyze_uploads_people_lmstudio.py, or None."""
-    return sidecar.read(upload_path)
+    """Read `imagename.meta.json` written by analyze_uploads_people_lmstudio.py, or empty dict."""
+    return sidecar.read(upload_path) or {}
 
 
 def _resolved_upload_target(filename: str):


### PR DESCRIPTION
## Summary
- Modified load_lmstudio_sidecar() in app.py to return empty dict {} instead of None when no .meta.json sidecar exists
- Prevents Jinja2 template error when detail.html calls .get() on None outside the {% if lmstudio_meta %} guard block

## Changes
- Changed return statement from return sidecar.read(upload_path) to return sidecar.read(upload_path) or {}

Closes #61