### PR TITLE
Fix: X button stops backend process (#65)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1064,6 +1064,13 @@ def lmstudio_start():
     return jsonify({"status": "starting", "model": model})
 
 
+@app.route("/api/lmstudio/stop", methods=["POST"])
+def lmstudio_stop():
+    import lmstudio as lms
+    lms.stop_server()
+    return jsonify({"status": "stopped"})
+
+
 def _start_lmstudio_background():
     global _lms_start_error
     base = lmstudio.LMSTUDIO_BASE

--- a/services/lmstudio.py
+++ b/services/lmstudio.py
@@ -10,6 +10,8 @@ import urllib.request
 
 LMSTUDIO_BACKEND = os.environ.get("LMSTUDIO_BACKEND", "lmstudio")
 
+_ollama_process = None
+
 DEFAULT_PORTS = {
     "lmstudio": "1234",
     "ollama": "11434",
@@ -141,9 +143,10 @@ def _run_cmd(*args: str) -> bool:
 
 
 def _start_server() -> bool:
+    global _ollama_process
     if LMSTUDIO_BACKEND == "ollama":
         try:
-            subprocess.Popen(
+            _ollama_process = subprocess.Popen(
                 ["ollama", "serve"],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
@@ -152,6 +155,25 @@ def _start_server() -> bool:
         except FileNotFoundError:
             return False
     return _run_cmd("lms", "server", "start")
+
+
+def stop_server() -> bool:
+    global _ollama_process
+    if LMSTUDIO_BACKEND == "ollama":
+        if _ollama_process is not None:
+            try:
+                _ollama_process.terminate()
+                _ollama_process.wait(timeout=5)
+                _ollama_process = None
+                return True
+            except Exception:
+                try:
+                    _ollama_process.kill()
+                    _ollama_process = None
+                except Exception:
+                    pass
+        return False
+    return _run_cmd("lms", "server", "stop")
 
 
 def _load_model(model: str) -> bool:

--- a/templates/lms_banner.html
+++ b/templates/lms_banner.html
@@ -78,6 +78,8 @@
 
   dismissBtn.addEventListener('click', function() {
     dismissed = true;
+    fetch('/api/lmstudio/stop', {method: 'POST'})
+      .catch(function() {});
     banner.classList.remove('visible');
   });
 


### PR DESCRIPTION
## Summary
- Adds `stop_server()` function in `lmstudio.py` that terminates the Popen process for Ollama or runs `lms server stop` for LM Studio
- Adds `POST /api/lmstudio/stop` endpoint in `app.py`
- Updates banner dismiss button to call the stop endpoint before hiding the banner