### PR TITLE
Fix: X button on LM Studio banner stops backend process (closes #65)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1064,6 +1064,14 @@ def lmstudio_start():
     return jsonify({"status": "starting", "model": model})
 
 
+@app.route("/api/lmstudio/stop", methods=["POST"])
+def lmstudio_stop():
+    success = lmstudio.stop_server()
+    if success:
+        return jsonify({"status": "stopped"})
+    return jsonify({"error": "Failed to stop server"}), 500
+
+
 def _start_lmstudio_background():
     global _lms_start_error
     base = lmstudio.LMSTUDIO_BASE

--- a/services/lmstudio.py
+++ b/services/lmstudio.py
@@ -19,6 +19,8 @@ LMSTUDIO_BASE = os.environ.get("LMSTUDIO_BASE", f"http://127.0.0.1:{DEFAULT_PORT
 LMSTUDIO_API_KEY = os.environ.get("LMSTUDIO_API_KEY", "lm-studio")
 LMSTUDIO_MODEL = os.environ.get("LMSTUDIO_MODEL", "")
 
+_ollama_process = None
+
 
 def describe_photo(image_path: str, base_url: str, model: str, api_key: str) -> str | None:
     """
@@ -141,9 +143,10 @@ def _run_cmd(*args: str) -> bool:
 
 
 def _start_server() -> bool:
+    global _ollama_process
     if LMSTUDIO_BACKEND == "ollama":
         try:
-            subprocess.Popen(
+            _ollama_process = subprocess.Popen(
                 ["ollama", "serve"],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
@@ -152,6 +155,22 @@ def _start_server() -> bool:
         except FileNotFoundError:
             return False
     return _run_cmd("lms", "server", "start")
+
+
+def stop_server() -> bool:
+    global _ollama_process
+    if LMSTUDIO_BACKEND == "ollama":
+        if _ollama_process is not None:
+            try:
+                _ollama_process.terminate()
+                _ollama_process.wait(timeout=5)
+                _ollama_process = None
+                return True
+            except Exception:
+                _ollama_process = None
+                return False
+        return True
+    return _run_cmd("lms", "server", "stop")
 
 
 def _load_model(model: str) -> bool:

--- a/templates/lms_banner.html
+++ b/templates/lms_banner.html
@@ -77,6 +77,9 @@
   var configuredModel = null;
 
   dismissBtn.addEventListener('click', function() {
+    fetch('/api/lmstudio/stop', {method: 'POST'})
+      .then(function() {})
+      .catch(function() {});
     dismissed = true;
     banner.classList.remove('visible');
   });


### PR DESCRIPTION
## Summary
- Add `stop_server()` function in `services/lmstudio.py` that handles both Ollama (terminate Popen handle) and LM Studio (`lms server stop`)
- Store Ollama Popen handle in global `_ollama_process` variable
- Add `POST /api/lmstudio/stop` endpoint in `app.py` using existing `lmstudio` import
- Update `lms_banner.html` dismiss button to call stop API before hiding banner