### PR TITLE
Feature: Options page with backend-agnostic model management (#66)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1072,6 +1072,39 @@ def lmstudio_stop():
     return jsonify({"error": "Failed to stop server"}), 500
 
 
+@app.route("/api/lmstudio/set-model", methods=["POST"])
+def lmstudio_set_model():
+    data = request.get_json() or {}
+    model = data.get("model", "")
+    if model:
+        os.environ["LMSTUDIO_MODEL"] = model
+    return jsonify({"status": "ok", "model": model})
+
+
+@app.route("/options")
+def options_page():
+    base = lmstudio.LMSTUDIO_BASE
+    backend = lmstudio.LMSTUDIO_BACKEND
+    configured_model = os.environ.get("LMSTUDIO_MODEL", "")
+    server_status = "online" if lmstudio.server_is_up(base) else "offline"
+    model_state = "unloaded"
+    if server_status == "online" and configured_model:
+        model_state = "loaded" if lmstudio.model_is_loaded(base, configured_model) else "unloaded"
+    available_models = []
+    if server_status == "online":
+        available_models = lmstudio.get_available_models(base)
+    return render_template(
+        "options.html",
+        backend=backend,
+        base_url=base,
+        server_status=server_status,
+        model_state=model_state,
+        configured_model=configured_model,
+        available_models=available_models,
+        lms_start_error=_lms_start_error,
+    )
+
+
 def _start_lmstudio_background():
     global _lms_start_error
     base = lmstudio.LMSTUDIO_BASE

--- a/templates/library.html
+++ b/templates/library.html
@@ -338,6 +338,7 @@
       <a href="{{ url_for('upload_form') }}" class="is-active">Library</a>
       <a href="{{ url_for('people_page') }}">People</a>
       <a href="{{ url_for('search_page') }}">Search</a>
+      <a href="{{ url_for('options_page') }}">Options</a>
     </nav>
     {% include 'lms_banner.html' %}
     <header>

--- a/templates/lms_banner.html
+++ b/templates/lms_banner.html
@@ -1,18 +1,23 @@
 <style>
   #lms-banner {
     margin: 0 0 1rem;
-    padding: 0.6rem 0.8rem;
-    border-radius: 8px;
-    font-size: 0.85rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: calc(var(--radius) - 4px);
+    font-size: 0.8rem;
     line-height: 1.4;
     display: none;
     align-items: center;
     gap: 0.5rem;
+    text-decoration: none;
   }
   #lms-banner.visible { display: flex; }
   .lms-banner--ready { color: #c8e6c9; background: rgba(76, 175, 80, 0.15); border: 1px solid rgba(76, 175, 80, 0.45); }
   .lms-banner--starting { color: #fff9c4; background: rgba(255, 193, 7, 0.15); border: 1px solid rgba(255, 193, 7, 0.45); }
   .lms-banner--offline { color: #ffcdd2; background: rgba(229, 57, 53, 0.15); border: 1px solid rgba(229, 57, 53, 0.45); }
+  .lms-banner--ready a, .lms-banner--starting a, .lms-banner--offline a {
+    color: inherit;
+    text-decoration: underline;
+  }
   #lms-dot {
     display: inline-block;
     width: 8px;
@@ -24,125 +29,28 @@
   .lms-banner--ready #lms-dot { background: #4caf50; }
   .lms-banner--starting #lms-dot { background: #ffc107; }
   #lms-label { flex: 1; }
-  #lms-model-select {
-    font-size: 0.8rem;
-    padding: 0.2rem 0.4rem;
-    border-radius: 4px;
-    border: 1px solid #888;
-    background: #fff;
-    color: #333;
-  }
-  #lms-model-select:disabled { opacity: 0.6; }
-  #lms-dismiss {
-    background: none;
-    border: none;
-    color: inherit;
-    font: inherit;
-    cursor: pointer;
-    padding: 0 0.25rem;
-    opacity: 0.7;
-  }
-  #lms-dismiss:hover { opacity: 1; }
-  #lms-start {
-    padding: 0.25rem 0.6rem;
-    font-size: 0.8rem;
-    font-weight: 600;
-    font-family: inherit;
-    color: #0f1419;
-    background: #ffc107;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-  }
-  #lms-start:hover { background: #ffca28; }
-  #lms-start:disabled { opacity: 0.5; cursor: not-allowed; }
 </style>
-<div id="lms-banner" role="status" aria-live="polite">
+<a id="lms-banner" href="/options" role="status" aria-live="polite">
   <span id="lms-dot"></span>
   <span id="lms-label">LM Studio offline</span>
-  <select id="lms-model-select" style="display: none;"></select>
-  <button id="lms-start" type="button">Start</button>
-  <button id="lms-dismiss" type="button" aria-label="Dismiss">&times;</button>
-</div>
+</a>
 <script>
 (function() {
   var banner = document.getElementById('lms-banner');
   var dot = document.getElementById('lms-dot');
   var label = document.getElementById('lms-label');
-  var modelSelect = document.getElementById('lms-model-select');
-  var startBtn = document.getElementById('lms-start');
-  var dismissBtn = document.getElementById('lms-dismiss');
-  var dismissed = false;
-  var currentModel = null;
-  var configuredModel = null;
 
-  dismissBtn.addEventListener('click', function() {
-    fetch('/api/lmstudio/stop', {method: 'POST'})
-      .then(function() {})
-      .catch(function() {});
-    dismissed = true;
-    banner.classList.remove('visible');
-  });
-
-  startBtn.addEventListener('click', function() {
-    var selectedModel = modelSelect.value;
-    startBtn.disabled = true;
-    label.textContent = 'LM Studio starting...';
-    fetch('/api/lmstudio/start', {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({model: selectedModel || configuredModel})
-    })
-      .then(function(r) { return r.json(); })
-      .then(function(d) {
-        if (d.status === 'starting') {
-          currentModel = d.model || selectedModel || configuredModel;
-          setStatus('starting');
-        }
-      })
-      .catch(function() {
-        startBtn.disabled = false;
-        setStatus('offline');
-      });
-  });
-
-  function setStatus(state) {
+  function setStatus(state, model) {
     banner.classList.remove('visible', 'lms-banner--ready', 'lms-banner--starting', 'lms-banner--offline');
     if (state === 'ready') {
       banner.classList.add('visible', 'lms-banner--ready');
-      label.textContent = 'LM Studio ready';
-      startBtn.style.display = 'none';
+      label.textContent = model ? ('LM Studio ready: ' + model) : 'LM Studio ready';
     } else if (state === 'starting') {
       banner.classList.add('visible', 'lms-banner--starting');
       label.textContent = 'LM Studio starting...';
-      startBtn.style.display = 'none';
     } else {
       banner.classList.add('visible', 'lms-banner--offline');
-      label.textContent = 'LM Studio offline';
-      startBtn.style.display = 'inline-block';
-      startBtn.disabled = false;
-    }
-  }
-
-  function populateModels(models) {
-    modelSelect.innerHTML = '';
-    if (!models || models.length === 0) {
-      modelSelect.style.display = 'none';
-      return;
-    }
-    modelSelect.style.display = 'inline-block';
-    var defaultOpt = document.createElement('option');
-    defaultOpt.value = '';
-    defaultOpt.textContent = 'Select model...';
-    modelSelect.appendChild(defaultOpt);
-    for (var i = 0; i < models.length; i++) {
-      var opt = document.createElement('option');
-      opt.value = models[i];
-      opt.textContent = models[i];
-      if (configuredModel && models[i] === configuredModel) {
-        opt.selected = true;
-      }
-      modelSelect.appendChild(opt);
+      label.textContent = 'LM Studio offline — click to configure';
     }
   }
 
@@ -150,24 +58,20 @@
     fetch('/api/lmstudio/status')
       .then(function(r) { return r.json(); })
       .then(function(d) {
-        configuredModel = d.model_configured || null;
-        populateModels(d.available_models || []);
         if (d.error) {
-          console.error('LM Studio start error:', d.error);
-          setStatus('offline');
-          label.textContent = 'LM Studio error: ' + d.error;
+          setStatus('offline', null);
           return;
         }
         if (d.server === 'up' && d.model === 'loaded') {
-          setStatus('ready');
+          setStatus('ready', d.model_configured);
         } else if (d.server === 'up') {
-          setStatus('starting');
+          setStatus('starting', d.model_configured);
         } else {
-          setStatus('offline');
+          setStatus('offline', null);
         }
       })
       .catch(function() {
-        setStatus('offline');
+        setStatus('offline', null);
       });
   }
 

--- a/templates/options.html
+++ b/templates/options.html
@@ -1,0 +1,361 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="theme-color" content="#0f1419">
+  <title>Options</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0f1419;
+      --bg-elevated: #1a2332;
+      --bg-input: #243044;
+      --border: #2d3a4d;
+      --text: #e7ecf3;
+      --text-muted: #8b9aad;
+      --accent: #5b9fd4;
+      --accent-hover: #7eb6e8;
+      --radius: 12px;
+      --tap-min: 44px;
+      --font: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+    }
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100dvh;
+      font-family: var(--font);
+      font-size: 1rem;
+      line-height: 1.5;
+      color: var(--text);
+      background: var(--bg);
+      -webkit-font-smoothing: antialiased;
+      padding:
+        max(1rem, env(safe-area-inset-top))
+        max(1rem, env(safe-area-inset-right))
+        max(1.25rem, env(safe-area-inset-bottom))
+        max(1rem, env(safe-area-inset-left));
+    }
+    .wrap {
+      width: 100%;
+      max-width: 28rem;
+      margin: 0 auto;
+    }
+    nav {
+      display: flex;
+      gap: 0;
+      margin-bottom: 1.5rem;
+      border: 1px solid var(--border);
+      border-radius: calc(var(--radius) - 4px);
+      overflow: hidden;
+    }
+    nav a {
+      flex: 1;
+      text-align: center;
+      padding: 0.65rem 0.5rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      text-decoration: none;
+      background: var(--bg-input);
+    }
+    nav a.is-active {
+      color: var(--text);
+      background: var(--bg-elevated);
+      box-shadow: inset 0 -2px 0 0 var(--accent);
+    }
+    nav a + a { border-left: 1px solid var(--border); }
+    nav a:hover:not(.is-active) { color: var(--text); }
+    header { margin-bottom: 1.5rem; }
+    h1 {
+      font-size: clamp(1.35rem, 4vw, 1.6rem);
+      font-weight: 600;
+      letter-spacing: -0.02em;
+      margin: 0 0 0.35rem;
+    }
+    .lede {
+      margin: 0;
+      font-size: 0.9rem;
+      color: var(--text-muted);
+    }
+    h2 {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--text-muted);
+      margin: 0 0 0.65rem;
+    }
+    .card {
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1rem;
+      margin-bottom: 1.5rem;
+    }
+    .status-row {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.9rem;
+    }
+    .status-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+    .status-dot--online { background: #4caf50; }
+    .status-dot--offline { background: #f44336; }
+    .status-dot--starting { background: #ffc107; }
+    .status-label { flex: 1; }
+    .status-detail {
+      font-size: 0.8rem;
+      color: var(--text-muted);
+    }
+    .error-msg {
+      margin-top: 0.5rem;
+      padding: 0.5rem 0.75rem;
+      border-radius: calc(var(--radius) - 4px);
+      font-size: 0.85rem;
+      color: #ffcdd2;
+      background: rgba(229, 57, 53, 0.15);
+      border: 1px solid rgba(229, 57, 53, 0.45);
+    }
+    .form-row {
+      display: flex;
+      gap: 0.5rem;
+      margin-bottom: 0.75rem;
+    }
+    select {
+      flex: 1;
+      padding: 0.6rem 0.75rem;
+      font-size: 0.9rem;
+      font-family: inherit;
+      color: var(--text);
+      background: var(--bg-input);
+      border: 1px solid var(--border);
+      border-radius: calc(var(--radius) - 4px);
+      min-height: var(--tap-min);
+    }
+    select:disabled { opacity: 0.6; }
+    button {
+      padding: 0.6rem 1rem;
+      font-size: 0.9rem;
+      font-weight: 600;
+      font-family: inherit;
+      color: var(--bg);
+      background: var(--accent);
+      border: none;
+      border-radius: calc(var(--radius) - 4px);
+      cursor: pointer;
+      min-height: var(--tap-min);
+    }
+    button:hover { background: var(--accent-hover); }
+    button:active { transform: scale(0.98); }
+    button:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+    .btn-secondary {
+      color: var(--text);
+      background: var(--bg-input);
+      border: 1px solid var(--border);
+    }
+    .btn-secondary:hover { background: var(--bg-elevated); }
+    .btn-danger {
+      color: #ffcdd2;
+      background: rgba(229, 57, 53, 0.18);
+      border: 1px solid rgba(229, 57, 53, 0.45);
+    }
+    .btn-danger:hover {
+      background: rgba(229, 57, 53, 0.32);
+    }
+    .controls-row {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+    .empty {
+      margin: 0;
+      padding: 1rem;
+      text-align: center;
+      font-size: 0.9rem;
+      color: var(--text-muted);
+      border: 1px dashed var(--border);
+      border-radius: calc(var(--radius) - 4px);
+    }
+    .info-row {
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      margin-bottom: 0.5rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <nav>
+      <a href="{{ url_for('upload_form') }}">Library</a>
+      <a href="{{ url_for('people_page') }}">People</a>
+      <a href="{{ url_for('search_page') }}">Search</a>
+      <a href="{{ url_for('options_page') }}" class="is-active">Options</a>
+    </nav>
+    <header>
+      <h1>AI Backend Options</h1>
+      <p class="lede">Configure LM Studio or Ollama backend</p>
+    </header>
+
+    <section class="card" aria-labelledby="backend-heading">
+      <h2 id="backend-heading">Backend Status</h2>
+      <div class="status-row">
+        <span class="status-dot status-dot--{% if server_status == 'online' %}online{% elif server_status == 'starting' %}starting{% else %}offline{% endif %}"></span>
+        <span class="status-label">Server: {{ server_status|title }}</span>
+      </div>
+      <div class="status-detail">
+        <p class="info-row">Backend: {{ backend }}</p>
+        <p class="info-row">URL: {{ base_url }}</p>
+      </div>
+      {% if lms_start_error %}
+      <div class="error-msg">{{ lms_start_error }}</div>
+      {% endif %}
+    </section>
+
+    <section class="card" aria-labelledby="model-heading">
+      <h2 id="model-heading">Model Management</h2>
+      <div class="form-row">
+        <select id="model-select">
+          <option value="">-- Select Model --</option>
+          {% for model in available_models %}
+          <option value="{{ model }}" {% if model == configured_model %}selected{% endif %}>{{ model }}</option>
+          {% endfor %}
+        </select>
+        <button id="set-model-btn" type="button">Set Model</button>
+      </div>
+      <div class="status-detail">
+        <p>Current: {% if configured_model %}{{ configured_model }}{% else %}None{% endif %}</p>
+        <p>State: {{ model_state }}</p>
+      </div>
+      <div class="controls-row" style="margin-top: 0.75rem;">
+        <button id="restart-model-btn" type="button" class="btn-secondary">Restart Model</button>
+      </div>
+      {% if not available_models %}
+      <p class="empty" style="margin-top: 0.75rem;">No models available. Start the server and load a model.</p>
+      {% endif %}
+    </section>
+
+    <section class="card" aria-labelledby="server-heading">
+      <h2 id="server-heading">Server Controls</h2>
+      <div class="controls-row">
+        <button id="start-server-btn" type="button">Start Server</button>
+        <button id="stop-server-btn" type="button" class="btn-danger">Stop Server</button>
+      </div>
+    </section>
+  </div>
+
+  <script>
+    (function() {
+      var modelSelect = document.getElementById('model-select');
+      var setModelBtn = document.getElementById('set-model-btn');
+      var restartModelBtn = document.getElementById('restart-model-btn');
+      var startServerBtn = document.getElementById('start-server-btn');
+      var stopServerBtn = document.getElementById('stop-server-btn');
+      var configuredModel = {{ configured_model|tojson }};
+
+      setModelBtn.addEventListener('click', function() {
+        var model = modelSelect.value;
+        if (!model) return;
+        setModelBtn.disabled = true;
+        fetch('/api/lmstudio/set-model', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({model: model})
+        })
+          .then(function(r) { return r.json(); })
+          .then(function(d) {
+            configuredModel = model;
+            location.reload();
+          })
+          .catch(function() {
+            setModelBtn.disabled = false;
+          });
+      });
+
+      restartModelBtn.addEventListener('click', function() {
+        restartModelBtn.disabled = true;
+        restartModelBtn.textContent = 'Stopping...';
+        fetch('/api/lmstudio/stop', {method: 'POST'})
+          .then(function() {
+            restartModelBtn.textContent = 'Starting...';
+            return fetch('/api/lmstudio/start', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({model: configuredModel})
+            });
+          })
+          .then(function(r) { return r.json(); })
+          .then(function(d) {
+            setTimeout(function() { location.reload(); }, 2000);
+          })
+          .catch(function() {
+            restartModelBtn.disabled = false;
+            restartModelBtn.textContent = 'Restart Model';
+          });
+      });
+
+      startServerBtn.addEventListener('click', function() {
+        startServerBtn.disabled = true;
+        startServerBtn.textContent = 'Starting...';
+        fetch('/api/lmstudio/start', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({model: modelSelect.value || configuredModel})
+        })
+          .then(function(r) { return r.json(); })
+          .then(function(d) {
+            setTimeout(function() { location.reload(); }, 2000);
+          })
+          .catch(function() {
+            startServerBtn.disabled = false;
+            startServerBtn.textContent = 'Start Server';
+          });
+      });
+
+      stopServerBtn.addEventListener('click', function() {
+        stopServerBtn.disabled = true;
+        stopServerBtn.textContent = 'Stopping...';
+        fetch('/api/lmstudio/stop', {method: 'POST'})
+          .then(function(r) { return r.json(); })
+          .then(function(d) {
+            setTimeout(function() { location.reload(); }, 1000);
+          })
+          .catch(function() {
+            stopServerBtn.disabled = false;
+            stopServerBtn.textContent = 'Stop Server';
+          });
+      });
+
+      setInterval(function() {
+        fetch('/api/lmstudio/status')
+          .then(function(r) { return r.json(); })
+          .then(function(d) {
+            if (d.available_models && d.available_models.length > 0) {
+              var current = modelSelect.value;
+              modelSelect.innerHTML = '<option value="">-- Select Model --</option>';
+              d.available_models.forEach(function(m) {
+                var opt = document.createElement('option');
+                opt.value = m;
+                opt.textContent = m;
+                if (d.model_configured && m === d.model_configured) {
+                  opt.selected = true;
+                }
+                modelSelect.appendChild(opt);
+              });
+              if (current) modelSelect.value = current;
+            }
+          })
+          .catch(function() {});
+      }, 3000);
+    })();
+  </script>
+</body>
+</html>

--- a/templates/people.html
+++ b/templates/people.html
@@ -177,6 +177,7 @@
       <a href="{{ url_for('upload_form') }}">Library</a>
       <a href="{{ url_for('people_page') }}" class="is-active">People</a>
       <a href="{{ url_for('search_page') }}">Search</a>
+      <a href="{{ url_for('options_page') }}">Options</a>
     </nav>
     {% include 'lms_banner.html' %}
     <header>

--- a/templates/search.html
+++ b/templates/search.html
@@ -328,6 +328,7 @@
       <a href="{{ url_for('upload_form') }}">Library</a>
       <a href="{{ url_for('people_page') }}">People</a>
       <a href="{{ url_for('search_page') }}" class="is-active">Search</a>
+      <a href="{{ url_for('options_page') }}">Options</a>
     </nav>
     {% include 'lms_banner.html' %}
     <header>


### PR DESCRIPTION
## Summary
- Added new `/options` page for managing AI backend (LM Studio or Ollama)
- Backend status display with connection status and error messages
- Model management: dropdown of available models, set model, restart model controls
- Server controls: Start/Stop buttons for both LM Studio and Ollama
- Added Options link to nav in Library, People, and Search pages
- Simplified banner to status indicator with link to `/options` instead of inline controls
- Auto-refresh every 3 seconds on options page
- Works with both LM Studio (`LMSTUDIO_BACKEND=lmstudio`) and Ollama (`LMSTUDIO_BACKEND=ollama`) backends

Closes #66