### PR TITLE
Feature: Select library photos as reference when adding a person (closes #75)

### DIFF
--- a/app.py
+++ b/app.py
@@ -368,20 +368,42 @@ def walkthrough():
         return render_template("walkthrough.html", step=1)
 
     if step == 2:
+        library_files = list_upload_folder()
+        image_exts = IMAGE_EXTENSIONS
         if request.method == "POST":
             name = request.form.get("name", "").strip()
             if not name:
-                return render_template("walkthrough.html", step=2, error="Name is required.")
-            photos = [f for f in request.files.getlist("photos") if f and f.filename]
-            if not photos:
-                return render_template("walkthrough.html", step=2, error="At least one reference photo is required.")
+                return render_template("walkthrough.html", step=2, error="Name is required.", library_photos=library_files, image_exts=image_exts)
+
+            uploaded_photos = [f for f in request.files.getlist("photos") if f and f.filename]
+            library_photo_selections = request.form.get("library_photos", "").strip()
+
+            selected_library = []
+            if library_photo_selections:
+                valid_lib = set(library_files)
+                for fn in library_photo_selections.split(","):
+                    fn = fn.strip()
+                    if fn and fn in valid_lib:
+                        selected_library.append(fn)
+
+            if not uploaded_photos and not selected_library:
+                return render_template("walkthrough.html", step=2, error="At least one reference photo is required.", library_photos=library_files, image_exts=image_exts)
 
             pid = str(uuid.uuid4())
             person_dir = os.path.join(PEOPLE_FOLDER, pid)
             os.makedirs(person_dir, exist_ok=True)
 
             saved_photos = []
-            for photo in photos:
+
+            for fn in selected_library:
+                src = os.path.join(UPLOAD_FOLDER, fn)
+                ext = fn.rsplit(".", 1)[-1].lower() if "." in fn else "jpg"
+                dest_name = secure_filename(f"{uuid.uuid4().hex}.{ext}")
+                dest = os.path.join(person_dir, dest_name)
+                shutil.copy(src, dest)
+                saved_photos.append(dest_name)
+
+            for photo in uploaded_photos:
                 ext = photo.filename.rsplit(".", 1)[-1].lower() if "." in photo.filename else "jpg"
                 safe_name = secure_filename(f"{uuid.uuid4().hex}.{ext}")
                 photo.save(os.path.join(person_dir, safe_name))
@@ -393,7 +415,7 @@ def walkthrough():
 
             return redirect(url_for("walkthrough", step=3, person_id=pid, person_name=name))
 
-        return render_template("walkthrough.html", step=2)
+        return render_template("walkthrough.html", step=2, library_photos=library_files, image_exts=image_exts)
 
     if step == 3:
         if not person_id:
@@ -417,23 +439,45 @@ def walkthrough():
 
 @app.route("/people/new", methods=["GET", "POST"])
 def new_person():
+    library_files = list_upload_folder()
+    image_exts = IMAGE_EXTENSIONS
+
     if request.method == "GET":
-        return render_template("person_form.html", person=None, error=None)
+        return render_template("person_form.html", person=None, error=None, library_photos=library_files, image_exts=image_exts)
 
     name = request.form.get("name", "").strip()
     if not name:
-        return render_template("person_form.html", person=None, error="Name is required."), 400
+        return render_template("person_form.html", person=None, error="Name is required.", library_photos=library_files, image_exts=image_exts), 400
 
-    photos = [f for f in request.files.getlist("photos") if f and f.filename]
-    if not photos:
-        return render_template("person_form.html", person=None, error="At least one reference photo is required."), 400
+    uploaded_photos = [f for f in request.files.getlist("photos") if f and f.filename]
+    library_photo_selections = request.form.get("library_photos", "").strip()
+
+    selected_library = []
+    if library_photo_selections:
+        valid_lib = set(library_files)
+        for fn in library_photo_selections.split(","):
+            fn = fn.strip()
+            if fn and fn in valid_lib:
+                selected_library.append(fn)
+
+    if not uploaded_photos and not selected_library:
+        return render_template("person_form.html", person=None, error="At least one reference photo is required.", library_photos=library_files, image_exts=image_exts), 400
 
     person_id = str(uuid.uuid4())
     person_dir = os.path.join(PEOPLE_FOLDER, person_id)
     os.makedirs(person_dir, exist_ok=True)
 
     saved_photos = []
-    for photo in photos:
+
+    for fn in selected_library:
+        src = os.path.join(UPLOAD_FOLDER, fn)
+        ext = fn.rsplit(".", 1)[-1].lower() if "." in fn else "jpg"
+        dest_name = secure_filename(f"{uuid.uuid4().hex}.{ext}")
+        dest = os.path.join(person_dir, dest_name)
+        shutil.copy(src, dest)
+        saved_photos.append(dest_name)
+
+    for photo in uploaded_photos:
         ext = photo.filename.rsplit(".", 1)[-1].lower() if "." in photo.filename else "jpg"
         safe_name = secure_filename(f"{uuid.uuid4().hex}.{ext}")
         photo.save(os.path.join(person_dir, safe_name))
@@ -458,16 +502,38 @@ def edit_person(person_id):
         person = json.load(f)
     person["id"] = person_id
 
+    library_files = list_upload_folder()
+    image_exts = IMAGE_EXTENSIONS
+
     if request.method == "GET":
-        return render_template("person_form.html", person=person, error=None)
+        return render_template("person_form.html", person=person, error=None, library_photos=library_files, image_exts=image_exts)
 
     name = request.form.get("name", "").strip()
     if not name:
-        return render_template("person_form.html", person=person, error="Name is required."), 400
+        return render_template("person_form.html", person=person, error="Name is required.", library_photos=library_files, image_exts=image_exts), 400
 
-    photos = [f for f in request.files.getlist("photos") if f and f.filename]
+    uploaded_photos = [f for f in request.files.getlist("photos") if f and f.filename]
+    library_photo_selections = request.form.get("library_photos", "").strip()
+
+    selected_library = []
+    if library_photo_selections:
+        valid_lib = set(library_files)
+        for fn in library_photo_selections.split(","):
+            fn = fn.strip()
+            if fn and fn in valid_lib:
+                selected_library.append(fn)
+
     new_photos = []
-    for photo in photos:
+
+    for fn in selected_library:
+        src = os.path.join(UPLOAD_FOLDER, fn)
+        ext = fn.rsplit(".", 1)[-1].lower() if "." in fn else "jpg"
+        dest_name = secure_filename(f"{uuid.uuid4().hex}.{ext}")
+        dest = os.path.join(person_dir, dest_name)
+        shutil.copy(src, dest)
+        new_photos.append(dest_name)
+
+    for photo in uploaded_photos:
         ext = photo.filename.rsplit(".", 1)[-1].lower() if "." in photo.filename else "jpg"
         safe_name = secure_filename(f"{uuid.uuid4().hex}.{ext}")
         photo.save(os.path.join(person_dir, safe_name))

--- a/templates/person_form.html
+++ b/templates/person_form.html
@@ -188,6 +188,62 @@
       color: var(--danger);
       margin-bottom: 1rem;
     }
+    .library-grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 0.4rem;
+      margin-top: 0.5rem;
+      max-height: 12rem;
+      overflow-y: auto;
+      padding: 0.25rem;
+      border: 1px solid var(--border);
+      border-radius: calc(var(--radius) - 4px);
+    }
+    .library-thumb {
+      position: relative;
+      aspect-ratio: 1;
+      border-radius: 6px;
+      overflow: hidden;
+      background: var(--bg-input);
+      border: 2px solid var(--border);
+      cursor: pointer;
+    }
+    .library-thumb.selected {
+      border-color: var(--accent);
+    }
+    .library-thumb img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+    .library-thumb .check {
+      position: absolute;
+      top: 4px;
+      right: 4px;
+      width: 18px;
+      height: 18px;
+      background: var(--accent);
+      border-radius: 50%;
+      display: none;
+      align-items: center;
+      justify-content: center;
+    }
+    .library-thumb.selected .check {
+      display: flex;
+    }
+    .library-thumb .check svg {
+      width: 12px;
+      height: 12px;
+      color: var(--bg);
+    }
+    .library-empty {
+      grid-column: 1 / -1;
+      padding: 1rem;
+      text-align: center;
+      font-size: 0.8rem;
+      color: var(--text-muted);
+    }
   </style>
 </head>
 <body>
@@ -227,6 +283,29 @@
         <input type="file" id="photos" name="photos" multiple accept=".jpg,.jpeg,.png,.gif">
         <p class="photo-hint">{{ "Select additional photos to add." if person else "At least one photo required. Hold Ctrl/Cmd to select multiple." }}</p>
       </div>
+      {% if library_photos %}
+      <div class="form-group">
+        <label>Or select from library</label>
+        <input type="hidden" id="library_photos" name="library_photos" value="">
+        <div class="library-grid" id="library_grid">
+          {% for fn in library_photos %}
+          {% set parts = fn.rsplit('.', 1) %}
+          {% set ext = parts[1].lower() if parts|length == 2 else '' %}
+          {% if ext in image_exts %}
+          <div class="library-thumb" data-filename="{{ fn | e }}" title="{{ fn | e }}">
+            <img src="{{ url_for('uploaded_file', filename=fn) }}" alt="" loading="lazy">
+            <div class="check">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="20 6 9 17 4 12"/>
+              </svg>
+            </div>
+          </div>
+          {% endif %}
+          {% endfor %}
+        </div>
+        <p class="photo-hint">Click to select. Selected photos are copied into this person's folder.</p>
+      </div>
+      {% endif %}
       <div class="actions">
         <a class="btn btn-secondary" href="{{ url_for('people_page') }}">Cancel</a>
         <button class="btn" type="submit">{{ "Save Changes" if person else "Create Person" }}</button>
@@ -238,5 +317,33 @@
     </form>
     {% endif %}
   </div>
+  <script>
+    (function() {
+      var grid = document.getElementById('library_grid');
+      if (!grid) return;
+      var input = document.getElementById('library_photos');
+      var thumbs = grid.querySelectorAll('.library-thumb');
+      var selected = [];
+
+      function updateInput() {
+        input.value = selected.join(',');
+      }
+
+      thumbs.forEach(function(thumb) {
+        thumb.addEventListener('click', function() {
+          var fn = thumb.dataset.filename;
+          var idx = selected.indexOf(fn);
+          if (idx > -1) {
+            selected.splice(idx, 1);
+            thumb.classList.remove('selected');
+          } else {
+            selected.push(fn);
+            thumb.classList.add('selected');
+          }
+          updateInput();
+        });
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/templates/walkthrough.html
+++ b/templates/walkthrough.html
@@ -254,6 +254,55 @@
       color: var(--text-muted);
       text-align: center;
     }
+    .library-grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 0.4rem;
+      margin-top: 0.5rem;
+      max-height: 12rem;
+      overflow-y: auto;
+      padding: 0.25rem;
+      border: 1px solid var(--border);
+      border-radius: calc(var(--radius) - 4px);
+    }
+    .library-thumb {
+      position: relative;
+      aspect-ratio: 1;
+      border-radius: 6px;
+      overflow: hidden;
+      background: var(--bg-input);
+      border: 2px solid var(--border);
+      cursor: pointer;
+    }
+    .library-thumb.selected {
+      border-color: var(--accent);
+    }
+    .library-thumb img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+    .library-thumb .check {
+      position: absolute;
+      top: 4px;
+      right: 4px;
+      width: 18px;
+      height: 18px;
+      background: var(--accent);
+      border-radius: 50%;
+      display: none;
+      align-items: center;
+      justify-content: center;
+    }
+    .library-thumb.selected .check {
+      display: flex;
+    }
+    .library-thumb .check svg {
+      width: 12px;
+      height: 12px;
+      color: var(--bg);
+    }
   </style>
 </head>
 <body>
@@ -291,10 +340,33 @@
         <input type="text" id="name" name="name" required placeholder="Enter person's name">
       </div>
       <div class="form-group">
-        <label for="photos">Reference Photo</label>
-        <input type="file" id="photos" name="photos" accept=".jpg,.jpeg,.png,.gif" required>
-        <p class="photo-hint">One clear, frontal photo works best.</p>
+        <label for="photos">Reference Photo (upload)</label>
+        <input type="file" id="photos" name="photos" accept=".jpg,.jpeg,.png,.gif">
+        <p class="photo-hint">Or select from library below.</p>
       </div>
+      {% if library_photos %}
+      <div class="form-group">
+        <label>Or select from library</label>
+        <input type="hidden" id="library_photos" name="library_photos" value="">
+        <div class="library-grid" id="library_grid">
+          {% for fn in library_photos %}
+          {% set parts = fn.rsplit('.', 1) %}
+          {% set ext = parts[1].lower() if parts|length == 2 else '' %}
+          {% if ext in image_exts %}
+          <div class="library-thumb" data-filename="{{ fn | e }}" title="{{ fn | e }}">
+            <img src="{{ url_for('uploaded_file', filename=fn) }}" alt="" loading="lazy">
+            <div class="check">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="20 6 9 17 4 12"/>
+              </svg>
+            </div>
+          </div>
+          {% endif %}
+          {% endfor %}
+        </div>
+        <p class="photo-hint">Click to select.</p>
+      </div>
+      {% endif %}
       <button class="btn" type="submit">Continue</button>
     </form>
     {% elif step == 3 %}
@@ -355,11 +427,39 @@
     <h1>All done!</h1>
     <p class="photo-count">{{ tagged_count }}</p>
     <p class="photo-count-label">photo{{ 's' if tagged_count != 1 else '' }} tagged</p>
-    <div class="done-actions">
+<div class="done-actions">
       <a class="btn btn-success" href="{{ url_for('person_detail', person_id=person_id) }}">View {{ person_name }}'s photos</a>
       <a class="btn btn-outline" href="{{ url_for('walkthrough', step=2) }}">Tag another person</a>
     </div>
-    {% endif %}
+  {% endif %}
   </div>
+  <script>
+    (function() {
+      var grid = document.getElementById('library_grid');
+      if (!grid) return;
+      var input = document.getElementById('library_photos');
+      var thumbs = grid.querySelectorAll('.library-thumb');
+      var selected = [];
+
+      function updateInput() {
+        input.value = selected.join(',');
+      }
+
+      thumbs.forEach(function(thumb) {
+        thumb.addEventListener('click', function() {
+          var fn = thumb.dataset.filename;
+          var idx = selected.indexOf(fn);
+          if (idx > -1) {
+            selected.splice(idx, 1);
+            thumb.classList.remove('selected');
+          } else {
+            selected.push(fn);
+            thumb.classList.add('selected');
+          }
+          updateInput();
+        });
+      });
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add library photo picker to `/people/new`, walkthrough step 2, and `/people/<id>/edit`
- Users can now select existing photos from the uploads library as reference photos
- Still supports uploading new photos via file input (existing flow preserved)
- Selected library photos are copied into the person's folder via `shutil.copy`
- Server-side validation ensures selections are in `list_upload_folder()` to prevent path traversal

## Changes
- `app.py`: Updated `new_person()`, `walkthrough()`, and `edit_person()` to handle `library_photos` POST param
- `templates/person_form.html`: Added scrollable thumbnail grid for library selection
- `templates/walkthrough.html`: Added library photo picker to step 2