### PR TITLE
Feature: Favorites — star photos and filter library to starred (closes #82)

### DIFF
--- a/app.py
+++ b/app.py
@@ -80,6 +80,34 @@ def list_upload_folder():
     )
 
 
+def list_favorited_files():
+    """Return list of files where sidecar metadata has favorited: true."""
+    if not os.path.isdir(UPLOAD_FOLDER):
+        return []
+    favorited = []
+    for f in os.listdir(UPLOAD_FOLDER):
+        if f.startswith("."):
+            continue
+        if f.endswith(".meta.json") or f == "_set_unique.meta.json":
+            continue
+        path = Path(UPLOAD_FOLDER) / f
+        if not path.is_file():
+            continue
+        meta = sidecar.read(path)
+        if meta and meta.get("favorited"):
+            favorited.append(f)
+    return sorted(favorited)
+
+
+def is_favorited(filename: str) -> bool:
+    """Check if a file is favorited via its sidecar metadata."""
+    path = Path(UPLOAD_FOLDER) / filename
+    if not path.is_file():
+        return False
+    meta = sidecar.read(path)
+    return bool(meta and meta.get("favorited"))
+
+
 def load_lmstudio_sidecar(upload_path: Path):
     """Read `imagename.meta.json` written by analyze_uploads_people_lmstudio.py, or empty dict."""
     return sidecar.read(upload_path) or {}
@@ -234,15 +262,23 @@ def _normalize_view_mode(raw) -> str:
 
 
 def _render_upload_page(
-    upload_message=None, upload_status="ok", view_mode="thumb", describe_job_id=None
+    upload_message=None,
+    upload_status="ok",
+    view_mode="thumb",
+    describe_job_id=None,
+    filter_mode="all",
 ):
+    files = list_favorited_files() if filter_mode == "favorites" else list_upload_folder()
+    favorited_set = {f for f in list_upload_folder() if is_favorited(f)}
     return render_template(
         "library.html",
-        files=list_upload_folder(),
+        files=files,
         upload_message=upload_message,
         upload_status=upload_status,
         view_mode=view_mode,
         describe_job_id=describe_job_id,
+        filter_mode=filter_mode,
+        favorited_set=favorited_set,
     )
 
 
@@ -251,7 +287,10 @@ def upload_form():
     if not list_people():
         return redirect(url_for("walkthrough", step=1))
     vm = _normalize_view_mode(request.args.get("view"))
-    return _render_upload_page(view_mode=vm)
+    filter_mode = request.args.get("filter", "all")
+    if filter_mode not in ("all", "favorites"):
+        filter_mode = "all"
+    return _render_upload_page(view_mode=vm, filter_mode=filter_mode)
 
 
 @app.route("/upload", methods=["POST"])
@@ -342,10 +381,26 @@ def delete_uploaded_file():
     return _render_upload_page(f"Deleted `{target.name}`.", "ok", vm), 200
 
 
+@app.route("/api/photos/<path:filename>/favorite", methods=["POST"])
+def toggle_favorite(filename: str):
+    """Toggle favorite status for a photo. Returns current favorited state."""
+    target = _resolved_upload_target(filename)
+    if target is None:
+        return jsonify({"error": "File not found"}), 404
+
+    current = sidecar.read(target) or {}
+    favorited = not current.get("favorited", False)
+    sidecar.merge(target, {"favorited": favorited})
+    return jsonify({"favorited": favorited})
+
+
 @app.route("/files")
 def list_files():
     vm = _normalize_view_mode(request.args.get("view"))
-    return _render_upload_page(view_mode=vm)
+    filter_mode = request.args.get("filter", "all")
+    if filter_mode not in ("all", "favorites"):
+        filter_mode = "all"
+    return _render_upload_page(view_mode=vm, filter_mode=filter_mode)
 
 
 @app.route("/people")
@@ -975,6 +1030,7 @@ def file_detail(filename):
     vm = _normalize_view_mode(request.args.get("view"))
     bundle = build_metadata_rows(target)
     lm_raw = load_lmstudio_sidecar(target)
+    favorited = is_favorited(filename)
     return render_template(
         "detail.html",
         filename=filename,
@@ -986,6 +1042,7 @@ def file_detail(filename):
         is_image=bundle["is_image"],
         meta_note=bundle["note"],
         lmstudio_meta=lm_raw,
+        favorited=favorited,
     )
 
 

--- a/templates/detail.html
+++ b/templates/detail.html
@@ -148,6 +148,13 @@
     .btn-delete:hover {
       background: rgba(229, 57, 53, 0.32);
     }
+    .btn-star {
+      color: var(--text-muted);
+      background: rgba(255, 255, 255, 0.08);
+      border: 1px solid var(--border);
+    }
+    .btn-star.is-favorited { color: #ffc107; }
+    .btn-star:hover { color: #ffcd4d; border-color: #ffcd4d; }
     nav {
       display: flex;
       gap: 0;
@@ -307,6 +314,7 @@
     {% endif %}
 
     <div class="actions">
+      <button type="button" class="btn btn-star {% if favorited %}is-favorited{% endif %}" id="btn-star" data-filename="{{ filename|e }}">{{ '★' if favorited else '☆' }}</button>
       <a class="btn btn-download" href="{{ download_url }}" download>Download</a>
       <form method="post" action="/delete" style="flex:1;min-width:8rem;margin:0;display:flex;"
             onsubmit="return confirm('Delete this file permanently?');">
@@ -316,5 +324,21 @@
       </form>
     </div>
   </div>
+  <script>
+    document.getElementById('btn-star').addEventListener('click', function() {
+      var btn = this;
+      var filename = btn.getAttribute('data-filename');
+      btn.disabled = true;
+      fetch('/api/photos/' + encodeURIComponent(filename) + '/favorite', {method: 'POST'})
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+          if (data.error) { btn.disabled = false; return; }
+          btn.classList.toggle('is-favorited', data.favorited);
+          btn.textContent = data.favorited ? '★' : '☆';
+          btn.disabled = false;
+        })
+        .catch(function() { btn.disabled = false; });
+    });
+  </script>
 </body>
 </html>

--- a/templates/library.html
+++ b/templates/library.html
@@ -233,6 +233,29 @@
       box-shadow: inset 0 -2px 0 0 var(--accent);
     }
     .view-switch a + a { border-left: 1px solid var(--border); }
+    .toolbar-row { display: flex; gap: 0.5rem; align-items: stretch; margin-bottom: 0.75rem; }
+    .filter-switch {
+      display: flex;
+      gap: 0;
+      border: 1px solid var(--border);
+      border-radius: calc(var(--radius) - 4px);
+      overflow: hidden;
+    }
+    .filter-switch a {
+      text-align: center;
+      padding: 0.55rem 0.65rem;
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      text-decoration: none;
+      background: var(--bg-input);
+    }
+    .filter-switch a.is-active {
+      color: var(--text);
+      background: var(--bg-elevated);
+      box-shadow: inset 0 -2px 0 0 var(--accent);
+    }
+    .filter-switch a + a { border-left: 1px solid var(--border); }
     ul.file-list {
       list-style: none;
       margin: 0;
@@ -330,6 +353,31 @@
       margin-top: 0.4rem;
       transition: width 0.2s;
     }
+    .thumb-star {
+      position: absolute;
+      top: 0.35rem;
+      right: 0.35rem;
+      width: 28px;
+      height: 28px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.4rem;
+      line-height: 1;
+      color: var(--text-muted);
+      background: rgba(15, 20, 25, 0.75);
+      border-radius: 50%;
+      cursor: pointer;
+      border: none;
+      opacity: 0;
+      transition: opacity 0.15s, color 0.15s;
+    }
+    .thumb-card:hover .thumb-star { opacity: 1; }
+    .thumb-star.is-favorited {
+      opacity: 1;
+      color: #ffc107;
+    }
+    .thumb-star:hover { color: #ffcd4d; }
   </style>
 </head>
 <body>
@@ -367,9 +415,15 @@
     {% endif %}
     <section aria-labelledby="files-heading">
       <h2 id="files-heading">Uploaded files</h2>
-      <div class="view-switch" role="group" aria-label="How to show files">
-        <a href="{{ url_for('upload_form', view='thumb') }}" class="{% if view_mode == 'thumb' %}is-active{% endif %}">Thumbnails</a>
-        <a href="{{ url_for('upload_form', view='list') }}" class="{% if view_mode == 'list' %}is-active{% endif %}">List</a>
+      <div class="toolbar-row">
+        <div class="filter-switch" role="group" aria-label="Filter files">
+          <a href="{{ url_for('upload_form', view=view_mode, filter='all') }}" class="{% if filter_mode == 'all' %}is-active{% endif %}">All</a>
+          <a href="{{ url_for('upload_form', view=view_mode, filter='favorites') }}" class="{% if filter_mode == 'favorites' %}is-active{% endif %}">Favorites</a>
+        </div>
+        <div class="view-switch" role="group" aria-label="How to show files">
+          <a href="{{ url_for('upload_form', view='thumb', filter=filter_mode) }}" class="{% if view_mode == 'thumb' %}is-active{% endif %}">Thumbnails</a>
+          <a href="{{ url_for('upload_form', view='list', filter=filter_mode) }}" class="{% if view_mode == 'list' %}is-active{% endif %}">List</a>
+        </div>
       </div>
       {% if files %}
         {% if view_mode == 'list' %}
@@ -399,6 +453,7 @@
               {% else %}
               <span class="thumb-placeholder"><span>{{ ext|upper if ext else 'FILE' }}</span></span>
               {% endif %}
+              <button type="button" class="thumb-star {% if filename in favorited_set %}is-favorited{% endif %}" aria-label="Toggle favorite" data-filename="{{ filename|e }}">{{ '★' if filename in favorited_set else '☆' }}</button>
             </a>
             <div class="thumb-meta">
               <a class="thumb-name" href="{{ url_for('file_detail', filename=filename, view=view_mode) }}">{{ filename }}</a>
@@ -421,6 +476,25 @@
     </section>
   </div>
   <script>
+    document.addEventListener('click', function(e) {
+      var star = e.target.closest('.thumb-star');
+      if (!star) return;
+      e.preventDefault();
+      var filename = star.getAttribute('data-filename');
+      star.disabled = true;
+      fetch('/api/photos/' + encodeURIComponent(filename) + '/favorite', {method: 'POST'})
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+          if (data.error) {
+            star.disabled = false;
+            return;
+          }
+          star.classList.toggle('is-favorited', data.favorited);
+          star.textContent = data.favorited ? '★' : '☆';
+          star.disabled = false;
+        })
+        .catch(function() { star.disabled = false; });
+    });
     function streamJob(jobId, onProgress, onDone) {
       var es = new EventSource('/api/jobs/' + encodeURIComponent(jobId));
       es.onmessage = function(e) {


### PR DESCRIPTION
## Summary
- Adds favorites feature allowing users to star photos
- Stores favorite state in each photo's `.meta.json` sidecar
- Adds `POST /api/photos//favorite` endpoint to toggle favorite
- Supports `?filter=favorites` URL param to filter library to starred photos
- Filter toggle button (All / Favorites) in library toolbar
- Star icon overlay on library thumbnails (appears on hover, clickable)
- Star button on file detail page

## Acceptance Criteria
- [x] Star icon on each thumbnail; click to toggle favorite
- [x] Star icon on file detail page  
- [x] `POST /api/photos//favorite` toggles and persists via sidecar
- [x] `?filter=favorites` shows only starred photos in library
- [x] Filter toggle button in library toolbar
- [x] Favorite state survives server restart (stored in sidecar)