### PR TITLE
Feature: Timeline view — browse library by date taken (closes #78)

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import time
 import uuid
+from datetime import datetime
 from pathlib import Path
 
 from flask import (
@@ -250,6 +251,56 @@ def build_metadata_rows(path: Path):
     }
 
 
+def get_photo_date(path: Path):
+    """Extract EXIF DateTimeOriginal, falling back to file mtime."""
+    ext = path.suffix.lower().lstrip(".")
+    if ext not in IMAGE_EXTENSIONS:
+        return None
+
+    try:
+        from PIL import Image
+    except ImportError:
+        return None
+
+    try:
+        with Image.open(path) as im:
+            exif = im.getexif()
+            if exif is not None:
+                from PIL.ExifTags import TAGS
+                for tag_id, val in exif.items():
+                    if TAGS.get(tag_id) == "DateTimeOriginal":
+                        s = _exif_value_to_str(val)
+                        if s:
+                            from datetime import datetime
+                            try:
+                                return datetime.strptime(s, "%Y:%m:%d %H:%M:%S")
+                            except ValueError:
+                                pass
+    except Exception:
+        pass
+
+    return None
+
+
+def list_files_by_date(files: list[str]) -> list[tuple[str, datetime | None]]:
+    """Return list of (filename, date) sorted by date descending."""
+    from datetime import datetime
+    base = Path(app.config["UPLOAD_FOLDER"])
+    result = []
+    for fname in files:
+        fpath = base / fname
+        photo_date = get_photo_date(fpath)
+        if photo_date is None:
+            try:
+                mtime = fpath.stat().st_mtime
+                photo_date = datetime.fromtimestamp(mtime)
+            except OSError:
+                photo_date = None
+        result.append((fname, photo_date))
+    result.sort(key=lambda p: (p[1] is None, p[1] if p[1] else datetime.min), reverse=True)
+    return result
+
+
 def _normalize_view_mode(raw) -> str:
     if not raw:
         return "thumb"
@@ -258,6 +309,8 @@ def _normalize_view_mode(raw) -> str:
         return "thumb"
     if v == "list":
         return "list"
+    if v == "timeline":
+        return "timeline"
     return "thumb"
 
 
@@ -270,6 +323,19 @@ def _render_upload_page(
 ):
     files = list_favorited_files() if filter_mode == "favorites" else list_upload_folder()
     favorited_set = {f for f in list_upload_folder() if is_favorited(f)}
+    timeline_groups = None
+    if view_mode == "timeline" and files:
+        from collections import defaultdict
+        dated_files = list_files_by_date(files)
+        groups = defaultdict(list)
+        for fname, dt in dated_files:
+            if dt is None:
+                key = "Unknown date"
+            else:
+                key = (dt.year, dt.month, f"{dt:%B %Y}")
+            groups[key].append((fname, dt))
+        sorted_keys = sorted(groups.keys(), key=lambda k: (k == "Unknown date", k), reverse=True)
+        timeline_groups = [(k[-1] if isinstance(k, tuple) else k, groups[k]) for k in sorted_keys]
     return render_template(
         "library.html",
         files=files,
@@ -279,6 +345,7 @@ def _render_upload_page(
         describe_job_id=describe_job_id,
         filter_mode=filter_mode,
         favorited_set=favorited_set,
+        timeline_groups=timeline_groups,
     )
 
 

--- a/templates/library.html
+++ b/templates/library.html
@@ -422,7 +422,8 @@
         </div>
         <div class="view-switch" role="group" aria-label="How to show files">
           <a href="{{ url_for('upload_form', view='thumb', filter=filter_mode) }}" class="{% if view_mode == 'thumb' %}is-active{% endif %}">Thumbnails</a>
-          <a href="{{ url_for('upload_form', view='list', filter=filter_mode) }}" class="{% if view_mode == 'list' %}is-active{% endif %}">List</a>
+          <a href="{{ url_for('upload_form', view='list', filter=filter_mode) %}" class="{% if view_mode == 'list' %}is-active{% endif %}">List</a>
+          <a href="{{ url_for('upload_form', view='timeline', filter=filter_mode) }}" class="{% if view_mode == 'timeline' %}is-active{% endif %}">Timeline</a>
         </div>
       </div>
       {% if files %}
@@ -439,6 +440,39 @@
         </li>
         {% endfor %}
       </ul>
+        {% elif view_mode == 'timeline' and timeline_groups %}
+          {% for month_label, month_files in timeline_groups %}
+      <h2>{{ month_label }}</h2>
+      <ul class="thumb-grid">
+              {% for filename, _ in month_files %}
+                {% set parts = filename.rsplit('.', 1) %}
+                {% set ext = parts[1].lower() if parts|length == 2 else '' %}
+                {% set is_img = ext in ['png', 'jpg', 'jpeg', 'gif'] %}
+        <li>
+          <div class="thumb-card">
+            <a class="thumb-preview" href="{{ url_for('file_detail', filename=filename, view=view_mode) }}" title="Details for {{ filename|e }}">
+              {% if is_img %}
+              <img src="{{ url_for('uploaded_file', filename=filename) }}" alt="" loading="lazy" width="200" height="200">
+              {% else %}
+              <span class="thumb-placeholder"><span>{{ ext|upper if ext else 'FILE' }}</span></span>
+              {% endif %}
+              <button type="button" class="thumb-star {% if filename in favorited_set %}is-favorited{% endif %}" aria-label="Toggle favorite" data-filename="{{ filename|e }}">{{ '★' if filename in favorited_set else '☆' }}</button>
+            </a>
+            <div class="thumb-meta">
+              <a class="thumb-name" href="{{ url_for('file_detail', filename=filename, view=view_mode) }}">{{ filename }}</a>
+              <div class="thumb-actions">
+                <form method="post" action="/delete" onsubmit="return confirm('Delete this file?');">
+                  <input type="hidden" name="filename" value="{{ filename|e }}">
+                  <input type="hidden" name="view" value="{{ view_mode }}">
+                  <button type="submit" class="btn-delete" aria-label="Delete {{ filename|e }}">Delete</button>
+                </form>
+              </div>
+            </div>
+          </div>
+        </li>
+              {% endfor %}
+      </ul>
+          {% endfor %}
         {% else %}
       <ul class="thumb-grid">
         {% for filename in files %}


### PR DESCRIPTION
## Summary
- Added timeline view that groups photos by Year → Month from EXIF DateTimeOriginal
- Falls back to file mtime if no EXIF date available
- Photos without any date are grouped under "Unknown date"
- New Timeline toggle in library view switcher alongside Thumbnails/List
- Reuses existing thumbnail grid styling
- Clicking photo still navigates to detail page