### PR TITLE
Feature: Timeline view — browse library by date taken (closes #78)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+import datetime
 import threading
 import json
 import os
@@ -80,6 +81,23 @@ def list_upload_folder():
     )
 
 
+def list_files_by_date(filter_mode: str = "all") -> list[tuple[str, datetime.datetime | None]]:
+    """Return list of (filename, date) sorted by date descending. None for unknown date."""
+    files = list_upload_folder()
+    if filter_mode == "favorites":
+        favorited_set = set(list_favorited_files())
+        files = [f for f in files if f in favorited_set]
+
+    result = []
+    for filename in files:
+        path = Path(UPLOAD_FOLDER) / filename
+        dt = get_photo_date(path)
+        result.append((filename, dt))
+
+    result.sort(key=lambda x: x[1] if x[1] else datetime.datetime.min, reverse=True)
+    return result
+
+
 def list_favorited_files():
     """Return list of files where sidecar metadata has favorited: true."""
     if not os.path.isdir(UPLOAD_FOLDER):
@@ -106,6 +124,38 @@ def is_favorited(filename: str) -> bool:
         return False
     meta = sidecar.read(path)
     return bool(meta and meta.get("favorited"))
+
+
+def get_photo_date(path: Path) -> datetime.datetime | None:
+    """Extract DateTimeOriginal from EXIF, or fall back to file mtime."""
+    ext = path.suffix.lower().lstrip(".")
+    if ext not in IMAGE_EXTENSIONS:
+        return None
+
+    try:
+        from PIL import Image
+    except ImportError:
+        return None
+
+    try:
+        with Image.open(path) as im:
+            exif = im.getexif()
+            if exif is not None:
+                from PIL.ExifTags import TAGS
+                for tag_id, val in exif.items():
+                    if TAGS.get(tag_id) == "DateTimeOriginal":
+                        try:
+                            return datetime.datetime.strptime(str(val), "%Y:%m:%d %H:%M:%S")
+                        except (ValueError, TypeError):
+                            pass
+    except Exception:
+        pass
+
+    try:
+        mtime = path.stat().st_mtime
+        return datetime.datetime.fromtimestamp(mtime)
+    except (OSError, ValueError):
+        return None
 
 
 def load_lmstudio_sidecar(upload_path: Path):
@@ -258,6 +308,8 @@ def _normalize_view_mode(raw) -> str:
         return "thumb"
     if v == "list":
         return "list"
+    if v == "timeline":
+        return "timeline"
     return "thumb"
 
 
@@ -270,6 +322,11 @@ def _render_upload_page(
 ):
     files = list_favorited_files() if filter_mode == "favorites" else list_upload_folder()
     favorited_set = {f for f in list_upload_folder() if is_favorited(f)}
+
+    timeline_groups = None
+    if view_mode == "timeline":
+        timeline_groups = _group_files_by_date(filter_mode)
+
     return render_template(
         "library.html",
         files=files,
@@ -279,7 +336,42 @@ def _render_upload_page(
         describe_job_id=describe_job_id,
         filter_mode=filter_mode,
         favorited_set=favorited_set,
+        timeline_groups=timeline_groups,
     )
+
+
+def _group_files_by_date(filter_mode: str) -> list[tuple[str, list[tuple[str, datetime.datetime | None]]]]:
+    """Group files by Year → Month. Returns list of (label, [(filename, date), ...])."""
+    files_with_dates = list_files_by_date(filter_mode)
+
+    groups = {}
+    unknown = []
+    for filename, dt in files_with_dates:
+        if dt is None:
+            unknown.append((filename, dt))
+            continue
+        year = dt.year
+        month = dt.month
+        key = (year, month)
+        if key not in groups:
+            groups[key] = []
+        groups[key].append((filename, dt))
+
+    for key in groups:
+        groups[key].sort(key=lambda x: x[1], reverse=True)
+
+    sorted_keys = sorted(groups.keys(), reverse=True)
+
+    result = []
+    for key in sorted_keys:
+        year, month = key
+        month_name = datetime.date(year, month, 1).strftime("%B %Y")
+        result.append((month_name, groups[key]))
+
+    if unknown:
+        result.append(("Unknown date", unknown))
+
+    return result
 
 
 @app.route("/", methods=["GET"])

--- a/templates/library.html
+++ b/templates/library.html
@@ -140,6 +140,12 @@
       color: var(--text-muted);
       margin: 0 0 0.65rem;
     }
+    section > h2 {
+      margin-top: 1.5rem;
+    }
+    section > h2:first-child {
+      margin-top: 0;
+    }
     .file-link {
       display: flex;
       align-items: center;
@@ -423,6 +429,7 @@
         <div class="view-switch" role="group" aria-label="How to show files">
           <a href="{{ url_for('upload_form', view='thumb', filter=filter_mode) }}" class="{% if view_mode == 'thumb' %}is-active{% endif %}">Thumbnails</a>
           <a href="{{ url_for('upload_form', view='list', filter=filter_mode) }}" class="{% if view_mode == 'list' %}is-active{% endif %}">List</a>
+          <a href="{{ url_for('upload_form', view='timeline', filter=filter_mode) }}" class="{% if view_mode == 'timeline' %}is-active{% endif %}">Timeline</a>
         </div>
       </div>
       {% if files %}
@@ -470,6 +477,41 @@
         {% endfor %}
       </ul>
         {% endif %}
+      {% elif view_mode == 'timeline' and timeline_groups %}
+        {% for group_label, group_files in timeline_groups %}
+      <section aria-labelledby="timeline-{{ loop.index }}">
+        <h2 id="timeline-{{ loop.index }}">{{ group_label }}</h2>
+      <ul class="thumb-grid">
+        {% for filename, photo_date in group_files %}
+        {% set parts = filename.rsplit('.', 1) %}
+        {% set ext = parts[1].lower() if parts|length == 2 else '' %}
+        {% set is_img = ext in ['png', 'jpg', 'jpeg', 'gif'] %}
+        <li>
+          <div class="thumb-card">
+            <a class="thumb-preview" href="{{ url_for('file_detail', filename=filename, view=view_mode) }}" title="Details for {{ filename|e }}">
+              {% if is_img %}
+              <img src="{{ url_for('uploaded_file', filename=filename) }}" alt="" loading="lazy" width="200" height="200">
+              {% else %}
+              <span class="thumb-placeholder"><span>{{ ext|upper if ext else 'FILE' }}</span></span>
+              {% endif %}
+              <button type="button" class="thumb-star {% if filename in favorited_set %}is-favorited{% endif %}" aria-label="Toggle favorite" data-filename="{{ filename|e }}">{{ '★' if filename in favorited_set else '☆' }}</button>
+            </a>
+            <div class="thumb-meta">
+              <a class="thumb-name" href="{{ url_for('file_detail', filename=filename, view=view_mode) }}">{{ filename }}</a>
+              <div class="thumb-actions">
+                <form method="post" action="/delete" onsubmit="return confirm('Delete this file?');">
+                  <input type="hidden" name="filename" value="{{ filename|e }}">
+                  <input type="hidden" name="view" value="{{ view_mode }}">
+                  <button type="submit" class="btn-delete" aria-label="Delete {{ filename|e }}">Delete</button>
+                </form>
+              </div>
+            </div>
+          </div>
+        </li>
+        {% endfor %}
+      </ul>
+      </section>
+        {% endfor %}
       {% else %}
       <p class="empty">No files yet — upload something above.</p>
       {% endif %}


### PR DESCRIPTION
## Summary
- Adds a new Timeline view mode to browse photos by date taken (EXIF DateTimeOriginal)
- Groups photos by Year → Month with section headers (e.g., "April 2025")
- Falls back to file mtime if no EXIF date available
- Photos without date are grouped under "Unknown date"
- Timeline toggle button added to library view switcher alongside Thumbnails/List
- Existing thumb and list views remain unaffected