### PR TITLE
Implement bulk actions for library photos (closes #80)

### DIFF
--- a/app.py
+++ b/app.py
@@ -327,6 +327,8 @@ def _render_upload_page(
     if view_mode == "timeline":
         timeline_groups = _group_files_by_date(filter_mode)
 
+    people = list_people()
+
     return render_template(
         "library.html",
         files=files,
@@ -337,6 +339,7 @@ def _render_upload_page(
         filter_mode=filter_mode,
         favorited_set=favorited_set,
         timeline_groups=timeline_groups,
+        people=people,
     )
 
 
@@ -471,6 +474,137 @@ def delete_uploaded_file():
     sidecar.delete(target)
 
     return _render_upload_page(f"Deleted `{target.name}`.", "ok", vm), 200
+
+
+MAX_BULK_FILES = 200
+
+
+def _validate_filenames(filenames: list[str]) -> tuple[list[str], list[str]]:
+    """Validate filenames against whitelist. Returns (valid, invalid)."""
+    valid_files = set(list_upload_folder())
+    valid = []
+    invalid = []
+    for fn in filenames:
+        fn = fn.strip()
+        if fn and fn in valid_files:
+            valid.append(fn)
+        elif fn:
+            invalid.append(fn)
+    return valid, invalid
+
+
+@app.route("/bulk/delete", methods=["POST"])
+def bulk_delete():
+    """Delete multiple files at once."""
+    vm = _normalize_view_mode(request.form.get("view"))
+    raw = request.form.get("filenames", "").strip()
+    if not raw:
+        return _render_upload_page("No files selected.", "err", vm), 400
+
+    filenames = [f.strip() for f in raw.split(",") if f.strip()]
+    valid, invalid = _validate_filenames(filenames)
+
+    if invalid:
+        return _render_upload_page(f"Invalid files ignored: {', '.join(invalid[:10])}", "ok", vm), 400
+
+    if not valid:
+        return _render_upload_page("No valid files to delete.", "err", vm), 400
+
+    if len(valid) > MAX_BULK_FILES:
+        return _render_upload_page(f"Too many files (max {MAX_BULK_FILES}).", "err", vm), 400
+
+    deleted = []
+    for fn in valid:
+        target = Path(UPLOAD_FOLDER) / fn
+        try:
+            if target.is_file():
+                target.unlink()
+                sidecar.delete(target)
+                deleted.append(fn)
+        except OSError:
+            pass
+
+    return _render_upload_page(f"Deleted {len(deleted)} file(s).", "ok", vm), 200
+
+
+@app.route("/bulk/tag", methods=["POST"])
+def bulk_tag():
+    """Tag multiple files with a person."""
+    vm = _normalize_view_mode(request.form.get("view"))
+    raw = request.form.get("filenames", "").strip()
+    person_id = request.form.get("person_id", "").strip()
+
+    if not raw:
+        return _render_upload_page("No files selected.", "err", vm), 400
+
+    if not person_id:
+        return _render_upload_page("No person selected.", "err", vm), 400
+
+    person = _get_person_or_404(person_id)
+    person_name = person.get("name", "")
+
+    filenames = [f.strip() for f in raw.split(",") if f.strip()]
+    valid, invalid = _validate_filenames(filenames)
+
+    if invalid:
+        return _render_upload_page(f"Invalid files ignored: {', '.join(invalid[:10])}", "ok", vm), 400
+
+    if not valid:
+        return _render_upload_page("No valid files to tag.", "err", vm), 400
+
+    if len(valid) > MAX_BULK_FILES:
+        return _render_upload_page(f"Too many files (max {MAX_BULK_FILES}).", "err", vm), 400
+
+    tagged = 0
+    for fn in valid:
+        image_path = Path(UPLOAD_FOLDER) / fn
+        if image_path.is_file():
+            current = sidecar.read(image_path) or {}
+            people_list = current.get("people", [])
+            if person_name not in people_list:
+                people_list.append(person_name)
+            sidecar.merge(image_path, {"people": people_list})
+            tagged += 1
+
+    return _render_upload_page(f"Tagged {tagged} photo(s) with {person_name}.", "ok", vm), 200
+
+
+@app.route("/bulk/download", methods=["POST"])
+def bulk_download():
+    """Download multiple files as a zip."""
+    import io
+    import zipfile
+
+    raw = request.form.get("filenames", "").strip()
+    if not raw:
+        abort(400)
+
+    filenames = [f.strip() for f in raw.split(",") if f.strip()]
+    valid, invalid = _validate_filenames(filenames)
+
+    if invalid:
+        abort(400)
+
+    if not valid:
+        abort(400)
+
+    if len(valid) > MAX_BULK_FILES:
+        abort(400)
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        for fn in valid:
+            src = Path(UPLOAD_FOLDER) / fn
+            if src.is_file():
+                data = src.read_bytes()
+                zf.writestr(fn, data)
+
+    buffer.seek(0)
+    return Response(
+        buffer.getvalue(),
+        mimetype="application/zip",
+        headers={"Content-Disposition": "attachment; filename=photos.zip"},
+    )
 
 
 @app.route("/api/photos/<path:filename>/favorite", methods=["POST"])

--- a/templates/library.html
+++ b/templates/library.html
@@ -420,6 +420,7 @@
       border: 2px solid var(--bg);
     }
     .thumb-card.is-selected .thumb-check { display: flex; }
+    .select-mode .thumb-check { display: flex; }
     .thumb-check.is-checked {
       background: var(--accent);
     }
@@ -765,6 +766,7 @@
       var personSelect = document.getElementById('person-select');
       var selectMode = false;
       var selectedFiles = new Set();
+      var thumbGrid = document.querySelector('.thumb-grid');
       function getFilename(el) {
         var card = el.closest('.thumb-card');
         return card ? card.getAttribute('data-filename') : null;
@@ -808,6 +810,7 @@
         selectMode = !selectMode;
         selectToggle.classList.toggle('is-active', selectMode);
         bulkActions.classList.toggle('visible', selectMode && selectedFiles.size > 0);
+        if (thumbGrid) thumbGrid.classList.toggle('select-mode', selectMode);
         if (!selectMode) {
           selectToggle.textContent = 'Select';
         } else {
@@ -820,6 +823,16 @@
         e.preventDefault();
         var filename = getFilename(check);
         if (filename) toggleSelection(filename);
+      });
+      document.addEventListener('click', function(e) {
+        if (!selectMode) return;
+        var card = e.target.closest('.thumb-card');
+        if (!card) return;
+        var filename = getFilename(card);
+        if (filename) {
+          e.preventDefault();
+          toggleSelection(filename);
+        }
       });
       bulkDelete.addEventListener('click', function() {
         var arr = Array.from(selectedFiles);

--- a/templates/library.html
+++ b/templates/library.html
@@ -384,6 +384,154 @@
       color: #ffc107;
     }
     .thumb-star:hover { color: #ffcd4d; }
+    .toolbar-row { display: flex; gap: 0.5rem; align-items: stretch; margin-bottom: 0.75rem; }
+    .toolbar-row.gap-between { justify-content: space-between; }
+    .select-toggle {
+      padding: 0.55rem 0.85rem;
+      font-size: 0.85rem;
+      font-weight: 600;
+      font-family: inherit;
+      color: var(--text);
+      background: var(--bg-input);
+      border: 1px solid var(--border);
+      border-radius: calc(var(--radius) - 4px);
+      cursor: pointer;
+    }
+    .select-toggle:hover { border-color: var(--accent); }
+    .select-toggle.is-active {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: var(--bg);
+    }
+    .thumb-check {
+      position: absolute;
+      top: 0.35rem;
+      left: 0.35rem;
+      width: 22px;
+      height: 22px;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      font-size: 1rem;
+      color: var(--bg);
+      background: rgba(91, 159, 212, 0.85);
+      border-radius: 4px;
+      cursor: pointer;
+      border: 2px solid var(--bg);
+    }
+    .thumb-card.is-selected .thumb-check { display: flex; }
+    .thumb-check.is-checked {
+      background: var(--accent);
+    }
+    .thumb-check.is-checked::after {
+      content: "✓";
+    }
+    .bulk-actions {
+      display: none;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      padding: 0.65rem 0.85rem;
+      background: var(--bg-elevated);
+      border: 1px solid var(--accent);
+      border-radius: calc(var(--radius) - 4px);
+      margin-bottom: 0.75rem;
+    }
+    .bulk-actions.visible { display: flex; }
+    .bulk-count {
+      flex: 1 1 100%;
+      font-size: 0.9rem;
+      color: var(--text-muted);
+      margin: 0;
+    }
+    .bulk-btn {
+      padding: 0.5rem 0.85rem;
+      font-size: 0.85rem;
+      font-weight: 600;
+      font-family: inherit;
+      border: none;
+      border-radius: calc(var(--radius) - 4px);
+      cursor: pointer;
+      min-height: 40px;
+    }
+    .bulk-btn--delete {
+      color: #ffcdd2;
+      background: rgba(229, 57, 53, 0.18);
+      border: 1px solid rgba(229, 57, 53, 0.45);
+    }
+    .bulk-btn--delete:hover {
+      background: rgba(229, 57, 53, 0.32);
+    }
+    .bulk-btn--tag {
+      color: var(--text);
+      background: var(--bg-input);
+      border: 1px solid var(--border);
+    }
+    .bulk-btn--tag:hover {
+      border-color: var(--accent);
+    }
+    .bulk-btn--download {
+      color: var(--bg);
+      background: var(--accent);
+    }
+    .bulk-btn--download:hover {
+      background: var(--accent-hover);
+    }
+    .tag-modal {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.75);
+      align-items: center;
+      justify-content: center;
+      z-index: 1000;
+    }
+    .tag-modal.visible { display: flex; }
+    .tag-modal-content {
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1.25rem;
+      width: 90%;
+      max-width: 20rem;
+    }
+    .tag-modal h3 {
+      margin: 0 0 1rem;
+      font-size: 1.1rem;
+    }
+    .tag-modal select {
+      width: 100%;
+      padding: 0.6rem 0.75rem;
+      font-size: 1rem;
+      font-family: inherit;
+      color: var(--text);
+      background: var(--bg-input);
+      border: 1px solid var(--border);
+      border-radius: calc(var(--radius) - 4px);
+      margin-bottom: 1rem;
+    }
+    .tag-modal-btns {
+      display: flex;
+      gap: 0.5rem;
+    }
+    .tag-modal-btns button {
+      flex: 1;
+      padding: 0.6rem 0.85rem;
+      font-size: 0.9rem;
+      font-weight: 600;
+      font-family: inherit;
+      border: none;
+      border-radius: calc(var(--radius) - 4px);
+      cursor: pointer;
+    }
+    .tag-modal-btns .btn-cancel {
+      color: var(--text-muted);
+      background: var(--bg-input);
+      border: 1px solid var(--border);
+    }
+    .tag-modal-btns .btn-confirm {
+      color: var(--bg);
+      background: var(--accent);
+    }
   </style>
 </head>
 <body>
@@ -421,7 +569,7 @@
     {% endif %}
     <section aria-labelledby="files-heading">
       <h2 id="files-heading">Uploaded files</h2>
-      <div class="toolbar-row">
+      <div class="toolbar-row gap-between">
         <div class="filter-switch" role="group" aria-label="Filter files">
           <a href="{{ url_for('upload_form', view=view_mode, filter='all') }}" class="{% if filter_mode == 'all' %}is-active{% endif %}">All</a>
           <a href="{{ url_for('upload_form', view=view_mode, filter='favorites') }}" class="{% if filter_mode == 'favorites' %}is-active{% endif %}">Favorites</a>
@@ -431,6 +579,13 @@
           <a href="{{ url_for('upload_form', view='list', filter=filter_mode) }}" class="{% if view_mode == 'list' %}is-active{% endif %}">List</a>
           <a href="{{ url_for('upload_form', view='timeline', filter=filter_mode) }}" class="{% if view_mode == 'timeline' %}is-active{% endif %}">Timeline</a>
         </div>
+        <button type="button" class="select-toggle" id="select-toggle">Select</button>
+      </div>
+      <div class="bulk-actions" id="bulk-actions">
+        <p class="bulk-count" id="bulk-count">0 selected</p>
+        <button type="button" class="bulk-btn bulk-btn--delete" id="bulk-delete">Delete</button>
+        <button type="button" class="bulk-btn bulk-btn--tag" id="bulk-tag">Tag Person</button>
+        <button type="button" class="bulk-btn bulk-btn--download" id="bulk-download">Download zip</button>
       </div>
       {% if files %}
         {% if view_mode == 'list' %}
@@ -453,7 +608,8 @@
         {% set ext = parts[1].lower() if parts|length == 2 else '' %}
         {% set is_img = ext in ['png', 'jpg', 'jpeg', 'gif'] %}
         <li>
-          <div class="thumb-card">
+          <div class="thumb-card" data-filename="{{ filename|e }}">
+            <button type="button" class="thumb-check" aria-label="Select {{ filename|e }}"></button>
             <a class="thumb-preview" href="{{ url_for('file_detail', filename=filename, view=view_mode) }}" title="Details for {{ filename|e }}">
               {% if is_img %}
               <img src="{{ url_for('uploaded_file', filename=filename) }}" alt="" loading="lazy" width="200" height="200">
@@ -516,6 +672,20 @@
       <p class="empty">No files yet — upload something above.</p>
       {% endif %}
     </section>
+    <div class="tag-modal" id="tag-modal" role="dialog" aria-labelledby="tag-modal-title">
+      <div class="tag-modal-content">
+        <h3 id="tag-modal-title">Tag with person</h3>
+        <select id="person-select">
+          {% for person in people %}
+          <option value="{{ person.id }}">{{ person.name }}</option>
+          {% endfor %}
+        </select>
+        <div class="tag-modal-btns">
+          <button type="button" class="btn-cancel" id="tag-cancel">Cancel</button>
+          <button type="button" class="btn-confirm" id="tag-confirm">Tag</button>
+        </div>
+      </div>
+    </div>
   </div>
   <script>
     document.addEventListener('click', function(e) {
@@ -580,6 +750,132 @@
         } else {
           bar.style.display = 'none';
         }
+      });
+    })();
+    (function() {
+      var selectToggle = document.getElementById('select-toggle');
+      var bulkActions = document.getElementById('bulk-actions');
+      var bulkCount = document.getElementById('bulk-count');
+      var bulkDelete = document.getElementById('bulk-delete');
+      var bulkTag = document.getElementById('bulk-tag');
+      var bulkDownload = document.getElementById('bulk-download');
+      var tagModal = document.getElementById('tag-modal');
+      var tagCancel = document.getElementById('tag-cancel');
+      var tagConfirm = document.getElementById('tag-confirm');
+      var personSelect = document.getElementById('person-select');
+      var selectMode = false;
+      var selectedFiles = new Set();
+      function getFilename(el) {
+        var card = el.closest('.thumb-card');
+        return card ? card.getAttribute('data-filename') : null;
+      }
+      function updateBulkUI() {
+        var count = selectedFiles.size;
+        bulkCount.textContent = count + ' selected';
+        bulkActions.classList.toggle('visible', count > 0);
+        if (count > 0) {
+          selectToggle.textContent = 'Cancel';
+          selectToggle.classList.add('is-active');
+        } else {
+          selectToggle.textContent = 'Select';
+          selectToggle.classList.remove('is-active');
+        }
+      }
+      function toggleSelection(filename) {
+        var card = document.querySelector('.thumb-card[data-filename="' + filename + '"]');
+        var check = card ? card.querySelector('.thumb-check') : null;
+        if (selectedFiles.has(filename)) {
+          selectedFiles.delete(filename);
+          if (card) card.classList.remove('is-selected');
+          if (check) check.classList.remove('is-checked');
+        } else {
+          selectedFiles.add(filename);
+          if (card) card.classList.add('is-selected');
+          if (check) check.classList.add('is-checked');
+        }
+        updateBulkUI();
+      }
+      if (!selectToggle) return;
+      selectToggle.addEventListener('click', function() {
+        if (selectedFiles.size > 0) {
+          selectedFiles.clear();
+          document.querySelectorAll('.thumb-card').forEach(function(card) {
+            card.classList.remove('is-selected');
+            var check = card.querySelector('.thumb-check');
+            if (check) check.classList.remove('is-checked');
+          });
+        }
+        selectMode = !selectMode;
+        selectToggle.classList.toggle('is-active', selectMode);
+        bulkActions.classList.toggle('visible', selectMode && selectedFiles.size > 0);
+        if (!selectMode) {
+          selectToggle.textContent = 'Select';
+        } else {
+          bulkCount.textContent = '0 selected';
+        }
+      });
+      document.addEventListener('click', function(e) {
+        var check = e.target.closest('.thumb-check');
+        if (!check) return;
+        e.preventDefault();
+        var filename = getFilename(check);
+        if (filename) toggleSelection(filename);
+      });
+      bulkDelete.addEventListener('click', function() {
+        var arr = Array.from(selectedFiles);
+        if (arr.length === 0) return;
+        if (!confirm('Delete ' + arr.length + ' photo(s)?')) return;
+        var form = document.createElement('form');
+        form.method = 'POST';
+        form.action = '/bulk/delete';
+        var filenames = document.createElement('input');
+        filenames.type = 'hidden';
+        filenames.name = 'filenames';
+        filenames.value = arr.join(',');
+        form.appendChild(filenames);
+        document.body.appendChild(form);
+        form.submit();
+      });
+      bulkTag.addEventListener('click', function() {
+        if (selectedFiles.size === 0) return;
+        tagModal.classList.add('visible');
+      });
+      tagCancel.addEventListener('click', function() {
+        tagModal.classList.remove('visible');
+      });
+      tagConfirm.addEventListener('click', function() {
+        var personId = personSelect.value;
+        if (!personId) return;
+        var arr = Array.from(selectedFiles);
+        var form = document.createElement('form');
+        form.method = 'POST';
+        form.action = '/bulk/tag';
+        var filenames = document.createElement('input');
+        filenames.type = 'hidden';
+        filenames.name = 'filenames';
+        filenames.value = arr.join(',');
+        var personIdInput = document.createElement('input');
+        personIdInput.type = 'hidden';
+        personIdInput.name = 'person_id';
+        personIdInput.value = personId;
+        form.appendChild(filenames);
+        form.appendChild(personIdInput);
+        document.body.appendChild(form);
+        form.submit();
+      });
+      bulkDownload.addEventListener('click', function() {
+        var arr = Array.from(selectedFiles);
+        if (arr.length === 0) return;
+        var form = document.createElement('form');
+        form.method = 'POST';
+        form.action = '/bulk/download';
+        var filenames = document.createElement('input');
+        filenames.type = 'hidden';
+        filenames.name = 'filenames';
+        filenames.value = arr.join(',');
+        form.appendChild(filenames);
+        document.body.appendChild(form);
+        form.submit();
       });
     })();
   </script>


### PR DESCRIPTION
## Summary
- Add select mode toggle in library toolbar to enable multi-select on thumbnails
- Add checkbox overlay on thumbnails when in select mode
- Add bulk action toolbar showing selected count with Delete, Tag Person, and Download zip buttons
- Implement server-side endpoints:
  - `/bulk/delete` - deletes files + sidecars with whitelist validation
  - `/bulk/tag` - tags files with a person using existing person picker
  - `/bulk/download` - streams selected files as a zip archive
- Server-side validation ensures filenames are whitelisted (must exist in uploads folder)
- Max 200 files per bulk operation

## Acceptance Criteria
- [x] Select mode toggle in library toolbar
- [x] Click to select/deselect thumbnails in select mode
- [x] Bulk delete works with confirm dialog
- [x] Bulk tag-person works with person picker
- [x] Bulk download produces valid zip of selected photos
- [x] All filenames validated server-side
- [x] Exiting select mode clears selection