### PR TITLE
Add Albums feature - group photos into named collections

### DIFF
--- a/app.py
+++ b/app.py
@@ -327,6 +327,8 @@ def _render_upload_page(
     if view_mode == "timeline":
         timeline_groups = _group_files_by_date(filter_mode)
 
+    people = list_people()
+
     return render_template(
         "library.html",
         files=files,
@@ -337,6 +339,7 @@ def _render_upload_page(
         filter_mode=filter_mode,
         favorited_set=favorited_set,
         timeline_groups=timeline_groups,
+        people=people,
     )
 
 
@@ -471,6 +474,137 @@ def delete_uploaded_file():
     sidecar.delete(target)
 
     return _render_upload_page(f"Deleted `{target.name}`.", "ok", vm), 200
+
+
+MAX_BULK_FILES = 200
+
+
+def _validate_filenames(filenames: list[str]) -> tuple[list[str], list[str]]:
+    """Validate filenames against whitelist. Returns (valid, invalid)."""
+    valid_files = set(list_upload_folder())
+    valid = []
+    invalid = []
+    for fn in filenames:
+        fn = fn.strip()
+        if fn and fn in valid_files:
+            valid.append(fn)
+        elif fn:
+            invalid.append(fn)
+    return valid, invalid
+
+
+@app.route("/bulk/delete", methods=["POST"])
+def bulk_delete():
+    """Delete multiple files at once."""
+    vm = _normalize_view_mode(request.form.get("view"))
+    raw = request.form.get("filenames", "").strip()
+    if not raw:
+        return _render_upload_page("No files selected.", "err", vm), 400
+
+    filenames = [f.strip() for f in raw.split(",") if f.strip()]
+    valid, invalid = _validate_filenames(filenames)
+
+    if invalid:
+        return _render_upload_page(f"Invalid files ignored: {', '.join(invalid[:10])}", "ok", vm), 400
+
+    if not valid:
+        return _render_upload_page("No valid files to delete.", "err", vm), 400
+
+    if len(valid) > MAX_BULK_FILES:
+        return _render_upload_page(f"Too many files (max {MAX_BULK_FILES}).", "err", vm), 400
+
+    deleted = []
+    for fn in valid:
+        target = Path(UPLOAD_FOLDER) / fn
+        try:
+            if target.is_file():
+                target.unlink()
+                sidecar.delete(target)
+                deleted.append(fn)
+        except OSError:
+            pass
+
+    return _render_upload_page(f"Deleted {len(deleted)} file(s).", "ok", vm), 200
+
+
+@app.route("/bulk/tag", methods=["POST"])
+def bulk_tag():
+    """Tag multiple files with a person."""
+    vm = _normalize_view_mode(request.form.get("view"))
+    raw = request.form.get("filenames", "").strip()
+    person_id = request.form.get("person_id", "").strip()
+
+    if not raw:
+        return _render_upload_page("No files selected.", "err", vm), 400
+
+    if not person_id:
+        return _render_upload_page("No person selected.", "err", vm), 400
+
+    person = _get_person_or_404(person_id)
+    person_name = person.get("name", "")
+
+    filenames = [f.strip() for f in raw.split(",") if f.strip()]
+    valid, invalid = _validate_filenames(filenames)
+
+    if invalid:
+        return _render_upload_page(f"Invalid files ignored: {', '.join(invalid[:10])}", "ok", vm), 400
+
+    if not valid:
+        return _render_upload_page("No valid files to tag.", "err", vm), 400
+
+    if len(valid) > MAX_BULK_FILES:
+        return _render_upload_page(f"Too many files (max {MAX_BULK_FILES}).", "err", vm), 400
+
+    tagged = 0
+    for fn in valid:
+        image_path = Path(UPLOAD_FOLDER) / fn
+        if image_path.is_file():
+            current = sidecar.read(image_path) or {}
+            people_list = current.get("people", [])
+            if person_name not in people_list:
+                people_list.append(person_name)
+            sidecar.merge(image_path, {"people": people_list})
+            tagged += 1
+
+    return _render_upload_page(f"Tagged {tagged} photo(s) with {person_name}.", "ok", vm), 200
+
+
+@app.route("/bulk/download", methods=["POST"])
+def bulk_download():
+    """Download multiple files as a zip."""
+    import io
+    import zipfile
+
+    raw = request.form.get("filenames", "").strip()
+    if not raw:
+        abort(400)
+
+    filenames = [f.strip() for f in raw.split(",") if f.strip()]
+    valid, invalid = _validate_filenames(filenames)
+
+    if invalid:
+        abort(400)
+
+    if not valid:
+        abort(400)
+
+    if len(valid) > MAX_BULK_FILES:
+        abort(400)
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        for fn in valid:
+            src = Path(UPLOAD_FOLDER) / fn
+            if src.is_file():
+                data = src.read_bytes()
+                zf.writestr(fn, data)
+
+    buffer.seek(0)
+    return Response(
+        buffer.getvalue(),
+        mimetype="application/zip",
+        headers={"Content-Disposition": "attachment; filename=photos.zip"},
+    )
 
 
 @app.route("/api/photos/<path:filename>/favorite", methods=["POST"])

--- a/app.py
+++ b/app.py
@@ -25,6 +25,7 @@ from services import confirmations, jobs, sidecar, lmstudio
 # --- Configuration ---
 UPLOAD_FOLDER = os.path.join(os.getcwd(), "uploads")
 PEOPLE_FOLDER = os.path.join(os.getcwd(), "people")
+ALBUMS_FOLDER = os.path.join(os.getcwd(), "albums")
 ALLOWED_EXTENSIONS = {"txt", "pdf", "png", "jpg", "jpeg", "gif"}
 IMAGE_EXTENSIONS = {"png", "jpg", "jpeg", "gif"}
 
@@ -34,6 +35,9 @@ app.config["UPLOAD_FOLDER"] = UPLOAD_FOLDER
 
 if not os.path.exists(UPLOAD_FOLDER):
     os.makedirs(UPLOAD_FOLDER)
+
+if not os.path.exists(ALBUMS_FOLDER):
+    os.makedirs(ALBUMS_FOLDER)
 
 _started_monotonic = time.monotonic()
 _lms_start_error = None
@@ -1248,6 +1252,105 @@ def search_page():
     return render_template("search.html", query=query, mode=mode, results=results, people=list_people())
 
 
+def list_albums():
+    if not os.path.isdir(ALBUMS_FOLDER):
+        return []
+    albums = []
+    for album_id in os.listdir(ALBUMS_FOLDER):
+        album_file = os.path.join(ALBUMS_FOLDER, album_id, "album.json")
+        if not os.path.isfile(album_file):
+            continue
+        try:
+            with open(album_file, "r", encoding="utf-8") as f:
+                album = json.load(f)
+            album["id"] = album_id
+            albums.append(album)
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            continue
+    return sorted(albums, key=lambda a: a.get("name", "").lower())
+
+
+def _get_album_or_404(album_id: str) -> dict:
+    album_file = os.path.join(ALBUMS_FOLDER, album_id, "album.json")
+    if not os.path.isfile(album_file):
+        abort(404)
+    with open(album_file, "r", encoding="utf-8") as f:
+        album = json.load(f)
+    album["id"] = album_id
+    return album
+
+
+@app.route("/albums")
+def albums_page():
+    albums = list_albums()
+    return render_template("albums.html", albums=albums)
+
+
+@app.route("/albums/<album_id>")
+def album_detail(album_id):
+    album = _get_album_or_404(album_id)
+    photos = album.get("photos", [])
+    valid_files = set(list_upload_folder())
+    valid_photos = [p for p in photos if p in valid_files]
+    return render_template("album_detail.html", album=album, photos=valid_photos)
+
+
+@app.route("/albums/new", methods=["POST"])
+def new_album():
+    name = request.form.get("name", "").strip()
+    if not name:
+        return redirect(url_for("albums_page"))
+    album_id = str(uuid.uuid4())
+    album_dir = os.path.join(ALBUMS_FOLDER, album_id)
+    os.makedirs(album_dir, exist_ok=True)
+    album_data = {
+        "id": album_id,
+        "name": name,
+        "photos": [],
+        "created_at": datetime.datetime.utcnow().isoformat(),
+    }
+    with open(os.path.join(album_dir, "album.json"), "w", encoding="utf-8") as f:
+        json.dump(album_data, f, indent=2)
+    return redirect(url_for("album_detail", album_id=album_id))
+
+
+@app.route("/albums/<album_id>/add", methods=["POST"])
+def add_to_album(album_id):
+    album = _get_album_or_404(album_id)
+    raw = request.form.get("filenames", "").strip()
+    if not raw:
+        return redirect(url_for("album_detail", album_id=album_id))
+    filenames = [f.strip() for f in raw.split(",") if f.strip()]
+    valid, invalid = _validate_filenames(filenames)
+    existing = set(album.get("photos", []))
+    added = [f for f in valid if f not in existing]
+    album["photos"] = album.get("photos", []) + added
+    album_file = os.path.join(ALBUMS_FOLDER, album_id, "album.json")
+    with open(album_file, "w", encoding="utf-8") as f:
+        json.dump(album, f, indent=2)
+    return redirect(url_for("album_detail", album_id=album_id))
+
+
+@app.route("/albums/<album_id>/remove", methods=["POST"])
+def remove_from_album(album_id):
+    album = _get_album_or_404(album_id)
+    filename = request.form.get("filename", "").strip()
+    if filename and filename in album.get("photos", []):
+        album["photos"] = [p for p in album["photos"] if p != filename]
+        album_file = os.path.join(ALBUMS_FOLDER, album_id, "album.json")
+        with open(album_file, "w", encoding="utf-8") as f:
+            json.dump(album, f, indent=2)
+    return redirect(url_for("album_detail", album_id=album_id))
+
+
+@app.route("/albums/<album_id>/delete", methods=["POST"])
+def delete_album(album_id):
+    _get_album_or_404(album_id)
+    album_dir = os.path.join(ALBUMS_FOLDER, album_id)
+    shutil.rmtree(album_dir)
+    return redirect(url_for("albums_page"))
+
+
 @app.route("/file/<path:filename>")
 def file_detail(filename):
     target = _resolved_upload_target(filename)
@@ -1257,6 +1360,7 @@ def file_detail(filename):
     bundle = build_metadata_rows(target)
     lm_raw = load_lmstudio_sidecar(target)
     favorited = is_favorited(filename)
+    albums = list_albums()
     return render_template(
         "detail.html",
         filename=filename,
@@ -1269,6 +1373,7 @@ def file_detail(filename):
         meta_note=bundle["note"],
         lmstudio_meta=lm_raw,
         favorited=favorited,
+        albums=albums,
     )
 
 

--- a/templates/album_detail.html
+++ b/templates/album_detail.html
@@ -1,0 +1,309 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="theme-color" content="#0f1419">
+  <title>{{ album.name|e }} — Album</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0f1419;
+      --bg-elevated: #1a2332;
+      --bg-input: #243044;
+      --border: #2d3a4d;
+      --text: #e7ecf3;
+      --text-muted: #8b9aad;
+      --accent: #5b9fd4;
+      --accent-hover: #7eb6e8;
+      --radius: 12px;
+      --tap-min: 44px;
+      --font: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+    }
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100dvh;
+      font-family: var(--font);
+      font-size: 1rem;
+      line-height: 1.5;
+      color: var(--text);
+      background: var(--bg);
+      -webkit-font-smoothing: antialiased;
+      padding:
+        max(1rem, env(safe-area-inset-top))
+        max(1rem, env(safe-area-inset-right))
+        max(1.25rem, env(safe-area-inset-bottom))
+        max(1rem, env(safe-area-inset-left));
+    }
+    .wrap { width: 100%; max-width: 28rem; margin: 0 auto; }
+    nav {
+      display: flex;
+      gap: 0;
+      margin-bottom: 1rem;
+      border: 1px solid var(--border);
+      border-radius: calc(var(--radius) - 4px);
+      overflow: hidden;
+    }
+    nav a {
+      flex: 1;
+      text-align: center;
+      padding: 0.65rem 0.5rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      text-decoration: none;
+      background: var(--bg-input);
+    }
+    nav a.is-active {
+      color: var(--text);
+      background: var(--bg-elevated);
+      box-shadow: inset 0 -2px 0 0 var(--accent);
+    }
+    nav a + a { border-left: 1px solid var(--border); }
+    nav a:hover:not(.is-active) { color: var(--text); }
+    .back {
+      display: inline-block;
+      margin-bottom: 1rem;
+      font-size: 0.9rem;
+      color: var(--accent);
+      text-decoration: none;
+    }
+    .back:hover { color: var(--accent-hover); }
+    h1 {
+      font-size: clamp(1.1rem, 3.5vw, 1.35rem);
+      font-weight: 600;
+      margin: 0 0 0.5rem;
+      word-break: break-word;
+    }
+    .lede {
+      margin: 0 0 1.25rem;
+      font-size: 0.9rem;
+      color: var(--text-muted);
+    }
+    .card {
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1rem;
+      margin-bottom: 1rem;
+    }
+    .add-form { margin: 0; display: flex; gap: 0.5rem; flex-direction: column; }
+    @media (min-width: 380px) {
+      .add-form { flex-direction: row; }
+    }
+    .add-form input[type="text"] {
+      flex: 1;
+      min-height: var(--tap-min);
+      padding: 0.5rem 0.75rem;
+      font-size: 0.95rem;
+      color: var(--text);
+      background: var(--bg-input);
+      border: 1px solid var(--border);
+      border-radius: calc(var(--radius) - 4px);
+    }
+    .add-form input[type="text"]:focus {
+      outline: none;
+      border-color: var(--accent);
+    }
+    .add-form input[type="submit"] {
+      min-height: var(--tap-min);
+      padding: 0 1rem;
+      font-size: 0.9rem;
+      font-weight: 600;
+      font-family: inherit;
+      color: var(--bg);
+      background: var(--accent);
+      border: none;
+      border-radius: calc(var(--radius) - 4px);
+      cursor: pointer;
+    }
+    .add-form input[type="submit"]:hover { background: var(--accent-hover); }
+    .hint {
+      font-size: 0.8rem;
+      color: var(--text-muted);
+      margin: 0.25rem 0 0;
+    }
+    .btn {
+      min-height: var(--tap-min);
+      padding: 0 1rem;
+      font-size: 0.9rem;
+      font-weight: 600;
+      font-family: inherit;
+      color: var(--bg);
+      background: var(--accent);
+      border: none;
+      border-radius: calc(var(--radius) - 4px);
+      cursor: pointer;
+      text-align: center;
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .btn:hover { background: var(--accent-hover); }
+    .btn--danger {
+      color: #ffcdd2;
+      background: rgba(229, 57, 53, 0.18);
+      border: 1px solid rgba(229, 57, 53, 0.45);
+    }
+    .btn--danger:hover {
+      background: rgba(229, 57, 53, 0.32);
+    }
+    .actions {
+      display: flex;
+      gap: 0.5rem;
+      margin-bottom: 1rem;
+    }
+    ul.thumb-grid {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0.75rem;
+    }
+    @media (min-width: 400px) {
+      ul.thumb-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    }
+    .thumb-card {
+      border: 1px solid var(--border);
+      border-radius: calc(var(--radius) - 4px);
+      overflow: hidden;
+      background: var(--bg-input);
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+      position: relative;
+    }
+    .thumb-preview {
+      display: block;
+      aspect-ratio: 1;
+      background: #0a0e14;
+    }
+    .thumb-preview img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+    .thumb-placeholder {
+      width: 100%;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.7rem;
+      font-weight: 700;
+      color: var(--text-muted);
+      letter-spacing: 0.06em;
+    }
+    .thumb-meta {
+      padding: 0.45rem 0.5rem 0.5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+      flex: 1;
+    }
+    .thumb-name {
+      font-size: 0.72rem;
+      color: var(--accent);
+      word-break: break-word;
+      text-decoration: none;
+      line-height: 1.25;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+    .thumb-name:hover { color: var(--accent-hover); }
+    .thumb-actions { margin-top: auto; }
+    .thumb-actions form { margin: 0; display: block; }
+    .thumb-remove {
+      min-height: 40px;
+      width: 100%;
+      font-size: 0.8rem;
+      font-weight: 600;
+      font-family: inherit;
+      color: #ffcdd2;
+      background: rgba(229, 57, 53, 0.18);
+      border: 1px solid rgba(229, 57, 53, 0.45);
+      border-radius: calc(var(--radius) - 4px);
+      cursor: pointer;
+    }
+    .thumb-remove:hover {
+      background: rgba(229, 57, 53, 0.32);
+    }
+    .empty {
+      margin: 0;
+      padding: 2rem 1rem;
+      text-align: center;
+      font-size: 0.9rem;
+      color: var(--text-muted);
+      border: 1px dashed var(--border);
+      border-radius: calc(var(--radius) - 4px);
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <nav>
+      <a href="{{ url_for('upload_form') }}">Library</a>
+      <a href="{{ url_for('albums_page') }}" class="is-active">Albums</a>
+      <a href="{{ url_for('people_page') }}">People</a>
+      <a href="{{ url_for('search_page') }}">Search</a>
+      <a href="{{ url_for('options_page') }}">Options</a>
+    </nav>
+    <a class="back" href="{{ url_for('albums_page') }}">← All albums</a>
+    <h1>{{ album.name|e }}</h1>
+    <p class="lede">{{ album.photos | length }} photo{% if album.photos | length != 1 %}s{% endif %}</p>
+    <div class="actions">
+      <a class="btn" href="{{ url_for('album_detail', album_id=album.id) }}">View</a>
+      <form method="post" action="{{ url_for('delete_album', album_id=album.id) }}" onsubmit="return confirm('Delete this album? Photos will remain in library.');">
+        <button type="submit" class="btn btn--danger">Delete album</button>
+      </form>
+    </div>
+    <section class="card">
+      <h2 style="font-size:0.72rem;font-weight:600;text-transform:uppercase;letter-spacing:0.06em;color:var(--text-muted);margin:0 0 0.75rem;">Add photos</h2>
+      <form class="add-form" method="post" action="{{ url_for('add_to_album', album_id=album.id) }}">
+        <input type="text" name="filenames" placeholder="Filename(s), comma-separated" required>
+        <input type="submit" value="Add">
+      </form>
+      <p class="hint">Enter filenames from your library, separated by commas.</p>
+    </section>
+    {% if photos %}
+    <ul class="thumb-grid">
+      {% for filename in photos %}
+      {% set parts = filename.rsplit('.', 1) %}
+      {% set ext = parts[1].lower() if parts|length == 2 else '' %}
+      {% set is_img = ext in ['png', 'jpg', 'jpeg', 'gif'] %}
+      <li>
+        <div class="thumb-card">
+          <a class="thumb-preview" href="{{ url_for('file_detail', filename=filename) }}" title="Details for {{ filename|e }}">
+            {% if is_img %}
+            <img src="{{ url_for('uploaded_file', filename=filename) }}" alt="" loading="lazy" width="200" height="200">
+            {% else %}
+            <span class="thumb-placeholder"><span>{{ ext|upper if ext else 'FILE' }}</span></span>
+            {% endif %}
+          </a>
+          <div class="thumb-meta">
+            <a class="thumb-name" href="{{ url_for('file_detail', filename=filename) }}">{{ filename }}</a>
+            <div class="thumb-actions">
+              <form method="post" action="{{ url_for('remove_from_album', album_id=album.id) }}">
+                <input type="hidden" name="filename" value="{{ filename|e }}">
+                <button type="submit" class="thumb-remove">Remove</button>
+              </form>
+            </div>
+          </div>
+        </div>
+      </li>
+      {% endfor %}
+    </ul>
+    {% else %}
+    <div class="empty">
+      <p>No photos in this album yet — add some above.</p>
+    </div>
+    {% endif %}
+  </div>
+</body>
+</html>

--- a/templates/albums.html
+++ b/templates/albums.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#0f1419">
-  <title>People</title>
+  <title>Albums</title>
   <style>
     :root {
       color-scheme: dark;
@@ -92,7 +92,45 @@
     }
     .btn:hover { background: var(--accent-hover); }
     .btn:active { transform: scale(0.98); }
-    ul.people-grid {
+    .card {
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1rem;
+      margin-bottom: 1.5rem;
+    }
+    .album-form { margin: 0; display: flex; gap: 0.5rem; }
+    @media (min-width: 380px) {
+      .album-form { flex-direction: row; }
+    }
+    .album-form input[type="text"] {
+      flex: 1;
+      min-height: var(--tap-min);
+      padding: 0.5rem 0.75rem;
+      font-size: 1rem;
+      color: var(--text);
+      background: var(--bg-input);
+      border: 1px solid var(--border);
+      border-radius: calc(var(--radius) - 4px);
+    }
+    .album-form input[type="text"]:focus {
+      outline: none;
+      border-color: var(--accent);
+    }
+    .album-form input[type="submit"] {
+      min-height: var(--tap-min);
+      padding: 0 1rem;
+      font-size: 0.9rem;
+      font-weight: 600;
+      font-family: inherit;
+      color: var(--bg);
+      background: var(--accent);
+      border: none;
+      border-radius: calc(var(--radius) - 4px);
+      cursor: pointer;
+    }
+    .album-form input[type="submit"]:hover { background: var(--accent-hover); }
+    ul.albums-grid {
       list-style: none;
       margin: 0;
       padding: 0;
@@ -101,9 +139,9 @@
       gap: 0.75rem;
     }
     @media (min-width: 400px) {
-      ul.people-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+      ul.albums-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
     }
-    .person-card {
+    .album-card {
       border: 1px solid var(--border);
       border-radius: calc(var(--radius) - 4px);
       overflow: hidden;
@@ -113,20 +151,20 @@
       min-width: 0;
       text-decoration: none;
     }
-    .person-card:hover { border-color: var(--accent); }
-    .person-preview {
+    .album-card:hover { border-color: var(--accent); }
+    .album-preview {
       display: block;
       aspect-ratio: 1;
       background: #0a0e14;
       position: relative;
     }
-    .person-preview img {
+    .album-preview img {
       width: 100%;
       height: 100%;
       object-fit: cover;
       display: block;
     }
-    .person-placeholder {
+    .album-placeholder {
       width: 100%;
       height: 100%;
       display: flex;
@@ -137,14 +175,14 @@
       color: var(--text-muted);
       letter-spacing: 0.06em;
     }
-    .person-meta {
+    .album-meta {
       padding: 0.45rem 0.5rem 0.5rem;
       display: flex;
       flex-direction: column;
       gap: 0.2rem;
       flex: 1;
     }
-    .person-name {
+    .album-name {
       font-size: 0.75rem;
       color: var(--text);
       font-weight: 600;
@@ -155,7 +193,7 @@
       -webkit-box-orient: vertical;
       overflow: hidden;
     }
-    .person-count {
+    .album-count {
       font-size: 0.7rem;
       color: var(--text-muted);
     }
@@ -175,34 +213,37 @@
   <div class="wrap">
     <nav>
       <a href="{{ url_for('upload_form') }}">Library</a>
-      <a href="{{ url_for('albums_page') }}">Albums</a>
-      <a href="{{ url_for('people_page') }}" class="is-active">People</a>
+      <a href="{{ url_for('albums_page') }}" class="is-active">Albums</a>
+      <a href="{{ url_for('people_page') }}">People</a>
       <a href="{{ url_for('search_page') }}">Search</a>
       <a href="{{ url_for('options_page') }}">Options</a>
     </nav>
-    {% include 'lms_banner.html' %}
     <header>
-      <h1>People</h1>
-      <p class="lede">Known people in your photo library</p>
+      <h1>Albums</h1>
+      <p class="lede">Group your photos into named collections</p>
     </header>
-    {% if people %}
-    <div style="margin-bottom:1rem;">
-      <a class="btn" href="{{ url_for('new_person') }}" style="font-size:0.9rem;min-height:40px;padding:0 1rem;">+ Add person</a>
-    </div>
-    <ul class="people-grid">
-      {% for person in people %}
+    <section class="card">
+      <h2 style="font-size:0.72rem;font-weight:600;text-transform:uppercase;letter-spacing:0.06em;color:var(--text-muted);margin:0 0 0.75rem;">Create album</h2>
+      <form class="album-form" method="post" action="{{ url_for('new_album') }}">
+        <input type="text" name="name" placeholder="Album name" required>
+        <input type="submit" value="Create">
+      </form>
+    </section>
+    {% if albums %}
+    <ul class="albums-grid">
+      {% for album in albums %}
       <li>
-        <a class="person-card" href="{{ url_for('person_detail', person_id=person.id) }}">
-          <div class="person-preview">
-            {% if person.reference_photos %}
-            <img src="{{ url_for('person_ref_photo', person_id=person.id, filename=person.reference_photos[0]) }}" alt="" loading="lazy" width="200" height="200">
+        <a class="album-card" href="{{ url_for('album_detail', album_id=album.id) }}">
+          <div class="album-preview">
+            {% if album.photos and album.photos[0] %}
+            <img src="{{ url_for('uploaded_file', filename=album.photos[0]) }}" alt="" loading="lazy" width="200" height="200">
             {% else %}
-            <div class="person-placeholder">NO PHOTO</div>
+            <div class="album-placeholder">EMPTY</div>
             {% endif %}
           </div>
-          <div class="person-meta">
-            <span class="person-name">{{ person.name | e }}</span>
-            <span class="person-count">{{ person.tagged_count }} photo{% if person.tagged_count != 1 %}s{% endif %}</span>
+          <div class="album-meta">
+            <span class="album-name">{{ album.name | e }}</span>
+            <span class="album-count">{{ album.photos | length }} photo{% if album.photos | length != 1 %}s{% endif %}</span>
           </div>
         </a>
       </li>
@@ -210,8 +251,7 @@
     </ul>
     {% else %}
     <div class="empty">
-      <p>No people added yet.</p>
-      <a class="btn" href="{{ url_for('new_person') }}">Add first person</a>
+      <p>No albums yet — create one above.</p>
     </div>
     {% endif %}
   </div>

--- a/templates/detail.html
+++ b/templates/detail.html
@@ -155,6 +155,12 @@
     }
     .btn-star.is-favorited { color: #ffc107; }
     .btn-star:hover { color: #ffcd4d; border-color: #ffcd4d; }
+    .btn-add-album {
+      color: var(--text);
+      background: var(--bg-input);
+      border: 1px solid var(--border);
+    }
+    .btn-add-album:hover { border-color: var(--accent); }
     nav {
       display: flex;
       gap: 0;
@@ -205,6 +211,7 @@
   <div class="wrap">
     <nav>
       <a href="{{ url_for('upload_form') }}" class="is-active">Library</a>
+      <a href="{{ url_for('albums_page') }}">Albums</a>
       <a href="{{ url_for('people_page') }}">People</a>
       <a href="{{ url_for('search_page') }}">Search</a>
     </nav>
@@ -315,6 +322,7 @@
 
     <div class="actions">
       <button type="button" class="btn btn-star {% if favorited %}is-favorited{% endif %}" id="btn-star" data-filename="{{ filename|e }}">{{ '★' if favorited else '☆' }}</button>
+      <button type="button" class="btn btn-add-album" id="btn-add-album">Add to album</button>
       <a class="btn btn-download" href="{{ download_url }}" download>Download</a>
       <form method="post" action="/delete" style="flex:1;min-width:8rem;margin:0;display:flex;"
             onsubmit="return confirm('Delete this file permanently?');">
@@ -322,6 +330,20 @@
         <input type="hidden" name="view" value="{{ view_mode }}">
         <button type="submit" class="btn btn-delete" style="width:100%">Delete</button>
       </form>
+    </div>
+    <div class="album-modal" id="album-modal" role="dialog" aria-labelledby="album-modal-title" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,0.75);align-items:center;justify-content:center;z-index:1000;">
+      <div style="background:var(--bg-elevated);border:1px solid var(--border);border-radius:var(--radius);padding:1.25rem;width:90%;max-width:20rem;">
+        <h3 id="album-modal-title" style="margin:0 0 1rem;font-size:1.1rem;">Add to album</h3>
+        <select id="album-select" style="width:100%;padding:0.6rem 0.75rem;font-size:1rem;font-family:inherit;color:var(--text);background:var(--bg-input);border:1px solid var(--border);border-radius:calc(var(--radius)-4px);margin-bottom:1rem;">
+          {% for album in albums %}
+          <option value="{{ album.id }}">{{ album.name | e }}</option>
+          {% endfor %}
+        </select>
+        <div style="display:flex;gap:0.5rem;">
+          <button type="button" class="btn btn-cancel" id="album-cancel" style="flex:1;padding:0.6rem 0.85rem;font-size:0.9rem;font-weight:600;font-family:inherit;color:var(--text-muted);background:var(--bg-input);border:1px solid var(--border);border-radius:calc(var(--radius)-4px);cursor:pointer;">Cancel</button>
+          <button type="button" class="btn btn-confirm" id="album-confirm" style="flex:1;padding:0.6rem 0.85rem;font-size:0.9rem;font-weight:600;font-family:inherit;color:var(--bg);background:var(--accent);border:none;border-radius:calc(var(--radius)-4px);cursor:pointer;">Add</button>
+        </div>
+      </div>
     </div>
   </div>
   <script>
@@ -339,6 +361,46 @@
         })
         .catch(function() { btn.disabled = false; });
     });
+    (function() {
+      var btnAddAlbum = document.getElementById('btn-add-album');
+      var albumModal = document.getElementById('album-modal');
+      var albumCancel = document.getElementById('album-cancel');
+      var albumConfirm = document.getElementById('album-confirm');
+      var albumSelect = document.getElementById('album-select');
+      if (!btnAddAlbum) return;
+      var albums = {{ albums|tojson }};
+      if (albums.length === 0) {
+        btnAddAlbum.addEventListener('click', function() {
+          alert('No albums yet. Create an album first.');
+        });
+        return;
+      }
+      btnAddAlbum.addEventListener('click', function() {
+        albumModal.style.display = 'flex';
+      });
+      albumCancel.addEventListener('click', function() {
+        albumModal.style.display = 'none';
+      });
+      albumConfirm.addEventListener('click', function() {
+        var albumId = albumSelect.value;
+        var filename = {{ filename|tojson }};
+        var form = document.createElement('form');
+        form.method = 'POST';
+        form.action = '/albums/' + albumId + '/add';
+        var input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = 'filenames';
+        input.value = filename;
+        form.appendChild(input);
+        document.body.appendChild(form);
+        form.submit();
+      });
+      albumModal.addEventListener('click', function(e) {
+        if (e.target === albumModal) {
+          albumModal.style.display = 'none';
+        }
+      });
+    })();
   </script>
 </body>
 </html>

--- a/templates/library.html
+++ b/templates/library.html
@@ -420,6 +420,7 @@
       border: 2px solid var(--bg);
     }
     .thumb-card.is-selected .thumb-check { display: flex; }
+    .select-mode .thumb-check { display: flex; }
     .thumb-check.is-checked {
       background: var(--accent);
     }
@@ -765,6 +766,7 @@
       var personSelect = document.getElementById('person-select');
       var selectMode = false;
       var selectedFiles = new Set();
+      var thumbGrid = document.querySelector('.thumb-grid');
       function getFilename(el) {
         var card = el.closest('.thumb-card');
         return card ? card.getAttribute('data-filename') : null;
@@ -808,6 +810,7 @@
         selectMode = !selectMode;
         selectToggle.classList.toggle('is-active', selectMode);
         bulkActions.classList.toggle('visible', selectMode && selectedFiles.size > 0);
+        if (thumbGrid) thumbGrid.classList.toggle('select-mode', selectMode);
         if (!selectMode) {
           selectToggle.textContent = 'Select';
         } else {
@@ -820,6 +823,16 @@
         e.preventDefault();
         var filename = getFilename(check);
         if (filename) toggleSelection(filename);
+      });
+      document.addEventListener('click', function(e) {
+        if (!selectMode) return;
+        var card = e.target.closest('.thumb-card');
+        if (!card) return;
+        var filename = getFilename(card);
+        if (filename) {
+          e.preventDefault();
+          toggleSelection(filename);
+        }
       });
       bulkDelete.addEventListener('click', function() {
         var arr = Array.from(selectedFiles);

--- a/templates/library.html
+++ b/templates/library.html
@@ -384,6 +384,154 @@
       color: #ffc107;
     }
     .thumb-star:hover { color: #ffcd4d; }
+    .toolbar-row { display: flex; gap: 0.5rem; align-items: stretch; margin-bottom: 0.75rem; }
+    .toolbar-row.gap-between { justify-content: space-between; }
+    .select-toggle {
+      padding: 0.55rem 0.85rem;
+      font-size: 0.85rem;
+      font-weight: 600;
+      font-family: inherit;
+      color: var(--text);
+      background: var(--bg-input);
+      border: 1px solid var(--border);
+      border-radius: calc(var(--radius) - 4px);
+      cursor: pointer;
+    }
+    .select-toggle:hover { border-color: var(--accent); }
+    .select-toggle.is-active {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: var(--bg);
+    }
+    .thumb-check {
+      position: absolute;
+      top: 0.35rem;
+      left: 0.35rem;
+      width: 22px;
+      height: 22px;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      font-size: 1rem;
+      color: var(--bg);
+      background: rgba(91, 159, 212, 0.85);
+      border-radius: 4px;
+      cursor: pointer;
+      border: 2px solid var(--bg);
+    }
+    .thumb-card.is-selected .thumb-check { display: flex; }
+    .thumb-check.is-checked {
+      background: var(--accent);
+    }
+    .thumb-check.is-checked::after {
+      content: "✓";
+    }
+    .bulk-actions {
+      display: none;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      padding: 0.65rem 0.85rem;
+      background: var(--bg-elevated);
+      border: 1px solid var(--accent);
+      border-radius: calc(var(--radius) - 4px);
+      margin-bottom: 0.75rem;
+    }
+    .bulk-actions.visible { display: flex; }
+    .bulk-count {
+      flex: 1 1 100%;
+      font-size: 0.9rem;
+      color: var(--text-muted);
+      margin: 0;
+    }
+    .bulk-btn {
+      padding: 0.5rem 0.85rem;
+      font-size: 0.85rem;
+      font-weight: 600;
+      font-family: inherit;
+      border: none;
+      border-radius: calc(var(--radius) - 4px);
+      cursor: pointer;
+      min-height: 40px;
+    }
+    .bulk-btn--delete {
+      color: #ffcdd2;
+      background: rgba(229, 57, 53, 0.18);
+      border: 1px solid rgba(229, 57, 53, 0.45);
+    }
+    .bulk-btn--delete:hover {
+      background: rgba(229, 57, 53, 0.32);
+    }
+    .bulk-btn--tag {
+      color: var(--text);
+      background: var(--bg-input);
+      border: 1px solid var(--border);
+    }
+    .bulk-btn--tag:hover {
+      border-color: var(--accent);
+    }
+    .bulk-btn--download {
+      color: var(--bg);
+      background: var(--accent);
+    }
+    .bulk-btn--download:hover {
+      background: var(--accent-hover);
+    }
+    .tag-modal {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.75);
+      align-items: center;
+      justify-content: center;
+      z-index: 1000;
+    }
+    .tag-modal.visible { display: flex; }
+    .tag-modal-content {
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1.25rem;
+      width: 90%;
+      max-width: 20rem;
+    }
+    .tag-modal h3 {
+      margin: 0 0 1rem;
+      font-size: 1.1rem;
+    }
+    .tag-modal select {
+      width: 100%;
+      padding: 0.6rem 0.75rem;
+      font-size: 1rem;
+      font-family: inherit;
+      color: var(--text);
+      background: var(--bg-input);
+      border: 1px solid var(--border);
+      border-radius: calc(var(--radius) - 4px);
+      margin-bottom: 1rem;
+    }
+    .tag-modal-btns {
+      display: flex;
+      gap: 0.5rem;
+    }
+    .tag-modal-btns button {
+      flex: 1;
+      padding: 0.6rem 0.85rem;
+      font-size: 0.9rem;
+      font-weight: 600;
+      font-family: inherit;
+      border: none;
+      border-radius: calc(var(--radius) - 4px);
+      cursor: pointer;
+    }
+    .tag-modal-btns .btn-cancel {
+      color: var(--text-muted);
+      background: var(--bg-input);
+      border: 1px solid var(--border);
+    }
+    .tag-modal-btns .btn-confirm {
+      color: var(--bg);
+      background: var(--accent);
+    }
   </style>
 </head>
 <body>
@@ -421,7 +569,7 @@
     {% endif %}
     <section aria-labelledby="files-heading">
       <h2 id="files-heading">Uploaded files</h2>
-      <div class="toolbar-row">
+      <div class="toolbar-row gap-between">
         <div class="filter-switch" role="group" aria-label="Filter files">
           <a href="{{ url_for('upload_form', view=view_mode, filter='all') }}" class="{% if filter_mode == 'all' %}is-active{% endif %}">All</a>
           <a href="{{ url_for('upload_form', view=view_mode, filter='favorites') }}" class="{% if filter_mode == 'favorites' %}is-active{% endif %}">Favorites</a>
@@ -431,6 +579,13 @@
           <a href="{{ url_for('upload_form', view='list', filter=filter_mode) }}" class="{% if view_mode == 'list' %}is-active{% endif %}">List</a>
           <a href="{{ url_for('upload_form', view='timeline', filter=filter_mode) }}" class="{% if view_mode == 'timeline' %}is-active{% endif %}">Timeline</a>
         </div>
+        <button type="button" class="select-toggle" id="select-toggle">Select</button>
+      </div>
+      <div class="bulk-actions" id="bulk-actions">
+        <p class="bulk-count" id="bulk-count">0 selected</p>
+        <button type="button" class="bulk-btn bulk-btn--delete" id="bulk-delete">Delete</button>
+        <button type="button" class="bulk-btn bulk-btn--tag" id="bulk-tag">Tag Person</button>
+        <button type="button" class="bulk-btn bulk-btn--download" id="bulk-download">Download zip</button>
       </div>
       {% if files %}
         {% if view_mode == 'list' %}
@@ -453,7 +608,8 @@
         {% set ext = parts[1].lower() if parts|length == 2 else '' %}
         {% set is_img = ext in ['png', 'jpg', 'jpeg', 'gif'] %}
         <li>
-          <div class="thumb-card">
+          <div class="thumb-card" data-filename="{{ filename|e }}">
+            <button type="button" class="thumb-check" aria-label="Select {{ filename|e }}"></button>
             <a class="thumb-preview" href="{{ url_for('file_detail', filename=filename, view=view_mode) }}" title="Details for {{ filename|e }}">
               {% if is_img %}
               <img src="{{ url_for('uploaded_file', filename=filename) }}" alt="" loading="lazy" width="200" height="200">
@@ -516,6 +672,20 @@
       <p class="empty">No files yet — upload something above.</p>
       {% endif %}
     </section>
+    <div class="tag-modal" id="tag-modal" role="dialog" aria-labelledby="tag-modal-title">
+      <div class="tag-modal-content">
+        <h3 id="tag-modal-title">Tag with person</h3>
+        <select id="person-select">
+          {% for person in people %}
+          <option value="{{ person.id }}">{{ person.name }}</option>
+          {% endfor %}
+        </select>
+        <div class="tag-modal-btns">
+          <button type="button" class="btn-cancel" id="tag-cancel">Cancel</button>
+          <button type="button" class="btn-confirm" id="tag-confirm">Tag</button>
+        </div>
+      </div>
+    </div>
   </div>
   <script>
     document.addEventListener('click', function(e) {
@@ -580,6 +750,132 @@
         } else {
           bar.style.display = 'none';
         }
+      });
+    })();
+    (function() {
+      var selectToggle = document.getElementById('select-toggle');
+      var bulkActions = document.getElementById('bulk-actions');
+      var bulkCount = document.getElementById('bulk-count');
+      var bulkDelete = document.getElementById('bulk-delete');
+      var bulkTag = document.getElementById('bulk-tag');
+      var bulkDownload = document.getElementById('bulk-download');
+      var tagModal = document.getElementById('tag-modal');
+      var tagCancel = document.getElementById('tag-cancel');
+      var tagConfirm = document.getElementById('tag-confirm');
+      var personSelect = document.getElementById('person-select');
+      var selectMode = false;
+      var selectedFiles = new Set();
+      function getFilename(el) {
+        var card = el.closest('.thumb-card');
+        return card ? card.getAttribute('data-filename') : null;
+      }
+      function updateBulkUI() {
+        var count = selectedFiles.size;
+        bulkCount.textContent = count + ' selected';
+        bulkActions.classList.toggle('visible', count > 0);
+        if (count > 0) {
+          selectToggle.textContent = 'Cancel';
+          selectToggle.classList.add('is-active');
+        } else {
+          selectToggle.textContent = 'Select';
+          selectToggle.classList.remove('is-active');
+        }
+      }
+      function toggleSelection(filename) {
+        var card = document.querySelector('.thumb-card[data-filename="' + filename + '"]');
+        var check = card ? card.querySelector('.thumb-check') : null;
+        if (selectedFiles.has(filename)) {
+          selectedFiles.delete(filename);
+          if (card) card.classList.remove('is-selected');
+          if (check) check.classList.remove('is-checked');
+        } else {
+          selectedFiles.add(filename);
+          if (card) card.classList.add('is-selected');
+          if (check) check.classList.add('is-checked');
+        }
+        updateBulkUI();
+      }
+      if (!selectToggle) return;
+      selectToggle.addEventListener('click', function() {
+        if (selectedFiles.size > 0) {
+          selectedFiles.clear();
+          document.querySelectorAll('.thumb-card').forEach(function(card) {
+            card.classList.remove('is-selected');
+            var check = card.querySelector('.thumb-check');
+            if (check) check.classList.remove('is-checked');
+          });
+        }
+        selectMode = !selectMode;
+        selectToggle.classList.toggle('is-active', selectMode);
+        bulkActions.classList.toggle('visible', selectMode && selectedFiles.size > 0);
+        if (!selectMode) {
+          selectToggle.textContent = 'Select';
+        } else {
+          bulkCount.textContent = '0 selected';
+        }
+      });
+      document.addEventListener('click', function(e) {
+        var check = e.target.closest('.thumb-check');
+        if (!check) return;
+        e.preventDefault();
+        var filename = getFilename(check);
+        if (filename) toggleSelection(filename);
+      });
+      bulkDelete.addEventListener('click', function() {
+        var arr = Array.from(selectedFiles);
+        if (arr.length === 0) return;
+        if (!confirm('Delete ' + arr.length + ' photo(s)?')) return;
+        var form = document.createElement('form');
+        form.method = 'POST';
+        form.action = '/bulk/delete';
+        var filenames = document.createElement('input');
+        filenames.type = 'hidden';
+        filenames.name = 'filenames';
+        filenames.value = arr.join(',');
+        form.appendChild(filenames);
+        document.body.appendChild(form);
+        form.submit();
+      });
+      bulkTag.addEventListener('click', function() {
+        if (selectedFiles.size === 0) return;
+        tagModal.classList.add('visible');
+      });
+      tagCancel.addEventListener('click', function() {
+        tagModal.classList.remove('visible');
+      });
+      tagConfirm.addEventListener('click', function() {
+        var personId = personSelect.value;
+        if (!personId) return;
+        var arr = Array.from(selectedFiles);
+        var form = document.createElement('form');
+        form.method = 'POST';
+        form.action = '/bulk/tag';
+        var filenames = document.createElement('input');
+        filenames.type = 'hidden';
+        filenames.name = 'filenames';
+        filenames.value = arr.join(',');
+        var personIdInput = document.createElement('input');
+        personIdInput.type = 'hidden';
+        personIdInput.name = 'person_id';
+        personIdInput.value = personId;
+        form.appendChild(filenames);
+        form.appendChild(personIdInput);
+        document.body.appendChild(form);
+        form.submit();
+      });
+      bulkDownload.addEventListener('click', function() {
+        var arr = Array.from(selectedFiles);
+        if (arr.length === 0) return;
+        var form = document.createElement('form');
+        form.method = 'POST';
+        form.action = '/bulk/download';
+        var filenames = document.createElement('input');
+        filenames.type = 'hidden';
+        filenames.name = 'filenames';
+        filenames.value = arr.join(',');
+        form.appendChild(filenames);
+        document.body.appendChild(form);
+        form.submit();
       });
     })();
   </script>

--- a/templates/library.html
+++ b/templates/library.html
@@ -539,6 +539,7 @@
   <div class="wrap">
     <nav>
       <a href="{{ url_for('upload_form') }}" class="is-active">Library</a>
+      <a href="{{ url_for('albums_page') }}">Albums</a>
       <a href="{{ url_for('people_page') }}">People</a>
       <a href="{{ url_for('search_page') }}">Search</a>
       <a href="{{ url_for('options_page') }}">Options</a>

--- a/templates/options.html
+++ b/templates/options.html
@@ -196,6 +196,7 @@
   <div class="wrap">
     <nav>
       <a href="{{ url_for('upload_form') }}">Library</a>
+      <a href="{{ url_for('albums_page') }}">Albums</a>
       <a href="{{ url_for('people_page') }}">People</a>
       <a href="{{ url_for('search_page') }}">Search</a>
       <a href="{{ url_for('options_page') }}" class="is-active">Options</a>

--- a/templates/person_detail.html
+++ b/templates/person_detail.html
@@ -216,6 +216,7 @@
   <div class="wrap">
     <nav>
       <a href="{{ url_for('upload_form') }}">Library</a>
+      <a href="{{ url_for('albums_page') }}">Albums</a>
       <a href="{{ url_for('people_page') }}" class="is-active">People</a>
       <a href="{{ url_for('search_page') }}">Search</a>
     </nav>

--- a/templates/person_form.html
+++ b/templates/person_form.html
@@ -250,6 +250,7 @@
   <div class="wrap">
     <nav>
       <a href="{{ url_for('upload_form') }}">Library</a>
+      <a href="{{ url_for('albums_page') }}">Albums</a>
       <a href="{{ url_for('people_page') }}">People</a>
       <a href="{{ url_for('search_page') }}">Search</a>
     </nav>

--- a/templates/search.html
+++ b/templates/search.html
@@ -326,6 +326,7 @@
   <div class="wrap">
     <nav>
       <a href="{{ url_for('upload_form') }}">Library</a>
+      <a href="{{ url_for('albums_page') }}">Albums</a>
       <a href="{{ url_for('people_page') }}">People</a>
       <a href="{{ url_for('search_page') }}" class="is-active">Search</a>
       <a href="{{ url_for('options_page') }}">Options</a>


### PR DESCRIPTION
## Summary
- Implements albums feature with JSON storage in `albums/<uuid>/album.json`
- Adds routes for creating, viewing, adding/removing photos, and deleting albums
- Adds Albums link to nav on all pages
- Adds "Add to album" button on file detail page

## Changes
- `app.py`: Added album routes and helper functions
- `templates/albums.html`: New albums list page
- `templates/album_detail.html`: New album detail with photo grid
- Updated nav in all existing templates to include Albums link
- `templates/detail.html`: Added "Add to album" button and modal

## Acceptance Criteria
- [x] GET /albums lists all albums with cover photo and count
- [x] GET /albums/<id> shows photo grid for that album
- [x] Create album form works
- [x] Photos can be added/removed from albums
- [x] Deleting album does not delete photos from library
- [x] Nav link to Albums present on all main pages

Closes #77