### PR TITLE
Feature: Duplicate detection — find and remove near-identical photos

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,7 +20,7 @@ from flask import (
 )
 from werkzeug.utils import secure_filename
 
-from services import confirmations, jobs, sidecar, lmstudio
+from services import confirmations, duplicates, jobs, sidecar, lmstudio
 
 # --- Configuration ---
 UPLOAD_FOLDER = os.path.join(os.getcwd(), "uploads")
@@ -1638,6 +1638,38 @@ def options_page():
         available_models=available_models,
         lms_start_error=_lms_start_error,
     )
+
+
+@app.route("/duplicates")
+def duplicates_page():
+    return render_template("duplicates.html")
+
+
+@app.route("/api/scan-duplicates", methods=["POST"])
+def start_scan_duplicates():
+    job_id = jobs.queue_job(
+        duplicates.scan_duplicates,
+        UPLOAD_FOLDER,
+    )
+    return jsonify({"job_id": job_id}), 202
+
+
+@app.route("/api/scan-duplicates/<job_id>")
+def stream_scan_duplicates(job_id):
+    job = jobs.get_job(job_id)
+    if job is None:
+        abort(404)
+
+    def generate():
+        for update in jobs.stream_progress(job_id):
+            data = {"progress": update.get("progress", 0), "message": update.get("message", "")}
+            if update.get("result") is not None:
+                data["result"] = update["result"]
+            if update.get("error"):
+                data["error"] = update["error"]
+            yield f"data: {json.dumps(data)}\n\n"
+
+    return Response(generate(), mimetype="text/event-stream")
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask>=3.0
 Pillow>=10.0
+imagehash>=4.1

--- a/services/duplicates.py
+++ b/services/duplicates.py
@@ -1,0 +1,142 @@
+"""
+Duplicate photo detection using SHA-256 for exact matches and pHash for near-duplicates.
+"""
+
+import hashlib
+import os
+from collections import defaultdict
+from pathlib import Path
+
+import imagehash
+from PIL import Image
+
+UPLOAD_FOLDER = os.path.join(os.getcwd(), "uploads")
+IMAGE_EXTENSIONS = {"png", "jpg", "jpeg", "gif"}
+
+
+def compute_sha256(filepath: Path) -> str:
+    """Compute SHA-256 hash of file content."""
+    h = hashlib.sha256()
+    with open(filepath, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def compute_phash(filepath: Path) -> str:
+    """Compute perceptual hash of an image."""
+    try:
+        with Image.open(filepath) as img:
+            return str(imagehash.phash(img))
+    except Exception:
+        return None
+
+
+def hamming_distance(hash1: str, hash2: str) -> int:
+    """Calculate Hamming distance between two hex strings."""
+    if hash1 is None or hash2 is None:
+        return 100
+    h1 = int(hash1, 16)
+    h2 = int(hash2, 16)
+    diff = h1 ^ h2
+    return bin(diff).count("1")
+
+
+def is_image_file(filename: str) -> bool:
+    """Check if file is an image based on extension."""
+    ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+    return ext in IMAGE_EXTENSIONS
+
+
+def scan_duplicates(job, upload_folder: str):
+    """
+    Scan upload folder for duplicate photos.
+    Uses SHA-256 for exact duplicates and pHash for near-duplicates (Hamming ≤ 10).
+    Returns list of duplicate groups: [[filename, filename, ...], ...]
+    """
+    job.set_progress(0, "Discovering files...")
+
+    files = [
+        f
+        for f in os.listdir(upload_folder)
+        if not f.startswith(".")
+        and os.path.isfile(os.path.join(upload_folder, f))
+        and not f.endswith(".meta.json")
+        and f != "_set_unique.meta.json"
+        and is_image_file(f)
+    ]
+
+    if not files:
+        job.set_result([])
+        return []
+
+    total = len(files)
+    processed = 0
+
+    sha256_groups = defaultdict(list)
+    phash_map = {}
+
+    for filename in files:
+        filepath = Path(upload_folder) / filename
+        job.set_progress(
+            int(processed / total * 50),
+            f"Hashing {filename}...",
+            current_file=filename,
+        )
+
+        sha = compute_sha256(filepath)
+        sha256_groups[sha].append(filename)
+
+        ph = compute_phash(filepath)
+        if ph:
+            phash_map[filename] = ph
+
+        processed += 1
+
+    exact_groups = [files for files in sha256_groups.values() if len(files) > 1]
+
+    job.set_progress(50, "Finding near-duplicates via pHash...")
+
+    filenames_with_hash = list(phash_map.keys())
+    near_duplicate_groups = []
+    used = set()
+
+    for i, fname1 in enumerate(filenames_with_hash):
+        if fname1 in used:
+            continue
+        hash1 = phash_map[fname1]
+        group = [fname1]
+
+        for fname2 in filenames_with_hash[i + 1 :]:
+            if fname2 in used:
+                continue
+            hash2 = phash_map[fname2]
+            dist = hamming_distance(hash1, hash2)
+            if dist <= 10:
+                group.append(fname2)
+                used.add(fname2)
+
+        if len(group) > 1:
+            near_duplicate_groups.append(group)
+            for f in group:
+                used.add(f)
+
+    merged_groups = []
+    all_seen = set()
+
+    for group in exact_groups:
+        merged_groups.append(group)
+        for f in group:
+            all_seen.add(f)
+
+    for group in near_duplicate_groups:
+        new_group = [f for f in group if f not in all_seen]
+        if len(new_group) > 1:
+            merged_groups.append(new_group)
+            for f in new_group:
+                all_seen.add(f)
+
+    job.set_progress(100, f"Found {len(merged_groups)} duplicate groups")
+
+    job.set_result(merged_groups)
+    return merged_groups

--- a/templates/album_detail.html
+++ b/templates/album_detail.html
@@ -254,6 +254,7 @@
       <a href="{{ url_for('map_page') }}">Map</a>
       <a href="{{ url_for('search_page') }}">Search</a>
       <a href="{{ url_for('options_page') }}">Options</a>
+      <a href="{{ url_for('duplicates_page') }}">Duplicates</a>
     </nav>
     <a class="back" href="{{ url_for('albums_page') }}">← All albums</a>
     <h1>{{ album.name|e }}</h1>

--- a/templates/albums.html
+++ b/templates/albums.html
@@ -218,6 +218,7 @@
       <a href="{{ url_for('map_page') }}">Map</a>
       <a href="{{ url_for('search_page') }}">Search</a>
       <a href="{{ url_for('options_page') }}">Options</a>
+      <a href="{{ url_for('duplicates_page') }}">Duplicates</a>
     </nav>
     <header>
       <h1>Albums</h1>

--- a/templates/detail.html
+++ b/templates/detail.html
@@ -216,6 +216,7 @@
       <a href="{{ url_for('map_page') }}">Map</a>
       <a href="{{ url_for('search_page') }}">Search</a>
       <a href="{{ url_for('options_page') }}">Options</a>
+      <a href="{{ url_for('duplicates_page') }}">Duplicates</a>
     </nav>
     {% include 'lms_banner.html' %}
     <a class="back" href="{{ url_for('upload_form', view=view_mode) }}">← All files</a>

--- a/templates/duplicates.html
+++ b/templates/duplicates.html
@@ -1,0 +1,383 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="theme-color" content="#0f1419">
+  <title>Duplicates</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0f1419;
+      --bg-elevated: #1a2332;
+      --bg-input: #243044;
+      --border: #2d3a4d;
+      --text: #e7ecf3;
+      --text-muted: #8b9aad;
+      --accent: #5b9fd4;
+      --accent-hover: #7eb6e8;
+      --radius: 12px;
+      --tap-min: 44px;
+      --font: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+    }
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100dvh;
+      font-family: var(--font);
+      font-size: 1rem;
+      line-height: 1.5;
+      color: var(--text);
+      background: var(--bg);
+      -webkit-font-smoothing: antialiased;
+      padding:
+        max(1rem, env(safe-area-inset-top))
+        max(1rem, env(safe-area-inset-right))
+        max(1.25rem, env(safe-area-inset-bottom))
+        max(1rem, env(safe-area-inset-left));
+    }
+    .wrap { width: 100%; max-width: 28rem; margin: 0 auto; }
+    nav {
+      display: flex;
+      gap: 0;
+      margin-bottom: 1.5rem;
+      border: 1px solid var(--border);
+      border-radius: calc(var(--radius) - 4px);
+      overflow: hidden;
+    }
+    nav a {
+      flex: 1;
+      text-align: center;
+      padding: 0.65rem 0.5rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      text-decoration: none;
+      background: var(--bg-input);
+    }
+    nav a.is-active {
+      color: var(--text);
+      background: var(--bg-elevated);
+      box-shadow: inset 0 -2px 0 0 var(--accent);
+    }
+    nav a + a { border-left: 1px solid var(--border); }
+    nav a:hover:not(.is-active) { color: var(--text); }
+    h1 {
+      font-size: clamp(1.35rem, 4vw, 1.6rem);
+      font-weight: 600;
+      letter-spacing: -0.02em;
+      margin: 0 0 0.35rem;
+    }
+    .lede {
+      margin: 0 0 1.25rem;
+      font-size: 0.9rem;
+      color: var(--text-muted);
+    }
+    .btn {
+      min-height: var(--tap-min);
+      padding: 0 1.1rem;
+      font-size: 1rem;
+      font-weight: 600;
+      font-family: inherit;
+      color: var(--bg);
+      background: var(--accent);
+      border: none;
+      border-radius: calc(var(--radius) - 4px);
+      cursor: pointer;
+      text-align: center;
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .btn:hover { background: var(--accent-hover); }
+    .btn:active { transform: scale(0.98); }
+    .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+    .btn-secondary {
+      color: var(--text);
+      background: var(--bg-input);
+    }
+    .btn-secondary:hover { background: var(--border); }
+    .btn-danger {
+      color: #fff;
+      background: #c94e4e;
+    }
+    .btn-danger:hover { background: #e06666; }
+    .card {
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1rem;
+      margin-bottom: 1.5rem;
+    }
+    .progress-bar {
+      height: 8px;
+      background: var(--bg-input);
+      border-radius: 4px;
+      overflow: hidden;
+      margin-top: 0.75rem;
+    }
+    .progress-fill {
+      height: 100%;
+      background: var(--accent);
+      transition: width 0.3s ease;
+    }
+    .status-text {
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      margin-top: 0.5rem;
+    }
+    .empty-state {
+      text-align: center;
+      padding: 2rem 1rem;
+      color: var(--text-muted);
+    }
+    .empty-state p { margin: 0; }
+    .group {
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1rem;
+      margin-bottom: 1rem;
+    }
+    .group-header {
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      margin-bottom: 0.75rem;
+    }
+    .photos {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+    }
+    .photo {
+      flex: 1 1 calc(50% - 0.375rem);
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .photo img {
+      width: 100%;
+      aspect-ratio: 1;
+      object-fit: cover;
+      border-radius: calc(var(--radius) - 4px);
+      background: var(--bg-input);
+    }
+    .photo .filename {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      margin-top: 0.35rem;
+      text-align: center;
+      word-break: break-all;
+      max-width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .photo .actions {
+      margin-top: 0.35rem;
+    }
+    .photo .actions button {
+      font-size: 0.75rem;
+      padding: 0.35rem 0.65rem;
+    }
+    .summary {
+      font-size: 0.9rem;
+      color: var(--text-muted);
+      margin-bottom: 1rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <nav>
+      <a href="/">Library</a>
+      <a href="/albums">Albums</a>
+      <a href="/people">People</a>
+      <a href="/duplicates" class="is-active">Duplicates</a>
+    </nav>
+
+    <h1>Duplicates</h1>
+    <p class="lede">Find and remove near-identical photos.</p>
+
+    <div class="card" id="scan-card">
+      <button class="btn" id="scan-btn" onclick="startScan()">Scan for Duplicates</button>
+      <div id="progress-section" style="display: none;">
+        <div class="progress-bar">
+          <div class="progress-fill" id="progress-fill" style="width: 0%;"></div>
+        </div>
+        <p class="status-text" id="status-text">Scanning...</p>
+      </div>
+    </div>
+
+    <div id="results-section">
+      <p class="summary" id="summary"></p>
+      <div id="groups"></div>
+      <div class="empty-state" id="empty-state" style="display: none;">
+        <p>No duplicates found</p>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    let currentJobId = null;
+    let duplicateGroups = [];
+
+    async function startScan() {
+      const scanBtn = document.getElementById('scan-btn');
+      const progressSection = document.getElementById('progress-section');
+      const progressFill = document.getElementById('progress-fill');
+      const statusText = document.getElementById('status-text');
+
+      scanBtn.disabled = true;
+      scanBtn.textContent = 'Scanning...';
+      progressSection.style.display = 'block';
+      progressFill.style.width = '0%';
+      statusText.textContent = 'Starting scan...';
+
+      try {
+        const resp = await fetch('/api/scan-duplicates', { method: 'POST' });
+        const data = await resp.json();
+        currentJobId = data.job_id;
+
+        const eventSource = new EventSource('/api/scan-duplicates/' + currentJobId);
+
+        eventSource.onmessage = function(e) {
+          const update = JSON.parse(e.data);
+          progressFill.style.width = update.progress + '%';
+          statusText.textContent = update.message || 'Scanning...';
+
+          if (update.result !== undefined && update.result !== null) {
+            duplicateGroups = update.result;
+            showResults(duplicateGroups);
+            scanBtn.disabled = false;
+            scanBtn.textContent = 'Scan for Duplicates';
+            eventSource.close();
+          }
+
+          if (update.error) {
+            statusText.textContent = 'Error: ' + update.error;
+            scanBtn.disabled = false;
+            scanBtn.textContent = 'Scan for Duplicates';
+            eventSource.close();
+          }
+        };
+
+        eventSource.onerror = function() {
+          eventSource.close();
+          scanBtn.disabled = false;
+          scanBtn.textContent = 'Scan for Duplicates';
+        };
+      } catch (err) {
+        statusText.textContent = 'Error: ' + err.message;
+        scanBtn.disabled = false;
+        scanBtn.textContent = 'Scan for Duplicates';
+      }
+    }
+
+    function showResults(groups) {
+      const summary = document.getElementById('summary');
+      const groupsDiv = document.getElementById('groups');
+      const emptyState = document.getElementById('empty-state');
+
+      groupsDiv.innerHTML = '';
+
+      if (!groups || groups.length === 0) {
+        summary.textContent = '';
+        emptyState.style.display = 'block';
+        return;
+      }
+
+      emptyState.style.display = 'none';
+      summary.textContent = groups.length + ' duplicate group' + (groups.length === 1 ? '' : 's') + ' found';
+
+      groups.forEach((group, idx) => {
+        const groupDiv = document.createElement('div');
+        groupDiv.className = 'group';
+
+        const header = document.createElement('p');
+        header.className = 'group-header';
+        header.textContent = 'Group ' + (idx + 1) + ' (' + group.length + ' photos)';
+        groupDiv.appendChild(header);
+
+        const photosDiv = document.createElement('div');
+        photosDiv.className = 'photos';
+
+        group.forEach((filename, photoIdx) => {
+          const photoDiv = document.createElement('div');
+          photoDiv.className = 'photo';
+
+          const img = document.createElement('img');
+          img.src = '/uploads/' + encodeURIComponent(filename);
+          img.alt = filename;
+          photoDiv.appendChild(img);
+
+          const nameSpan = document.createElement('p');
+          nameSpan.className = 'filename';
+          nameSpan.textContent = filename;
+          photoDiv.appendChild(nameSpan);
+
+          const actionsDiv = document.createElement('div');
+          actionsDiv.className = 'actions';
+
+          const isLast = (photoIdx === group.length - 1);
+          if (!isLast) {
+            const deleteBtn = document.createElement('button');
+            deleteBtn.className = 'btn btn-danger';
+            deleteBtn.textContent = 'Delete';
+            deleteBtn.onclick = () => deletePhoto(filename, group);
+            actionsDiv.appendChild(deleteBtn);
+          }
+          photoDiv.appendChild(actionsDiv);
+          photosDiv.appendChild(photoDiv);
+        });
+
+        groupDiv.appendChild(photosDiv);
+        groupsDiv.appendChild(groupDiv);
+      });
+    }
+
+    async function deletePhoto(filename, group) {
+      if (!confirm('Delete ' + filename + '?')) {
+        return;
+      }
+
+      const formData = new FormData();
+      formData.append('filename', filename);
+      formData.append('view', 'thumb');
+
+      try {
+        const resp = await fetch('/delete', {
+          method: 'POST',
+          body: formData
+        });
+
+        if (resp.ok) {
+          const idx = group.indexOf(filename);
+          if (idx > -1) {
+            group.splice(idx, 1);
+          }
+
+          const globalIdx = duplicateGroups.findIndex(g => g.includes(filename));
+          if (globalIdx > -1) {
+            const g = duplicateGroups[globalIdx];
+            const pIdx = g.indexOf(filename);
+            if (pIdx > -1) {
+              g.splice(pIdx, 1);
+            }
+
+            if (g.length <= 1) {
+              duplicateGroups.splice(globalIdx, 1);
+            }
+          }
+
+          showResults(duplicateGroups);
+        }
+      } catch (err) {
+        alert('Error deleting: ' + err.message);
+      }
+    }
+  </script>
+</body>
+</html>

--- a/templates/library.html
+++ b/templates/library.html
@@ -544,6 +544,7 @@
       <a href="{{ url_for('map_page') }}">Map</a>
       <a href="{{ url_for('search_page') }}">Search</a>
       <a href="{{ url_for('options_page') }}">Options</a>
+      <a href="{{ url_for('duplicates_page') }}">Duplicates</a>
     </nav>
     {% include 'lms_banner.html' %}
     <header>

--- a/templates/map.html
+++ b/templates/map.html
@@ -154,6 +154,7 @@
       <a href="{{ url_for('map_page') }}" class="is-active">Map</a>
       <a href="{{ url_for('search_page') }}">Search</a>
       <a href="{{ url_for('options_page') }}">Options</a>
+      <a href="{{ url_for('duplicates_page') }}">Duplicates</a>
     </nav>
     <header>
       <h1>Map</h1>

--- a/templates/options.html
+++ b/templates/options.html
@@ -201,6 +201,7 @@
       <a href="{{ url_for('map_page') }}">Map</a>
       <a href="{{ url_for('search_page') }}">Search</a>
       <a href="{{ url_for('options_page') }}" class="is-active">Options</a>
+      <a href="{{ url_for('duplicates_page') }}">Duplicates</a>
     </nav>
     <header>
       <h1>AI Backend Options</h1>

--- a/templates/people.html
+++ b/templates/people.html
@@ -180,6 +180,7 @@
       <a href="{{ url_for('map_page') }}">Map</a>
       <a href="{{ url_for('search_page') }}">Search</a>
       <a href="{{ url_for('options_page') }}">Options</a>
+      <a href="{{ url_for('duplicates_page') }}">Duplicates</a>
     </nav>
     {% include 'lms_banner.html' %}
     <header>

--- a/templates/person_detail.html
+++ b/templates/person_detail.html
@@ -220,6 +220,7 @@
       <a href="{{ url_for('people_page') }}" class="is-active">People</a>
       <a href="{{ url_for('map_page') }}">Map</a>
       <a href="{{ url_for('search_page') }}">Search</a>
+      <a href="{{ url_for('duplicates_page') }}">Duplicates</a>
     </nav>
     {% include 'lms_banner.html' %}
     <a class="back" href="{{ url_for('people_page') }}">&larr; People</a>

--- a/templates/person_form.html
+++ b/templates/person_form.html
@@ -254,6 +254,7 @@
       <a href="{{ url_for('people_page') }}">People</a>
       <a href="{{ url_for('map_page') }}">Map</a>
       <a href="{{ url_for('search_page') }}">Search</a>
+      <a href="{{ url_for('duplicates_page') }}">Duplicates</a>
     </nav>
     {% include 'lms_banner.html' %}
     <header>

--- a/templates/search.html
+++ b/templates/search.html
@@ -331,6 +331,7 @@
       <a href="{{ url_for('map_page') }}">Map</a>
       <a href="{{ url_for('search_page') }}" class="is-active">Search</a>
       <a href="{{ url_for('options_page') }}">Options</a>
+      <a href="{{ url_for('duplicates_page') }}">Duplicates</a>
     </nav>
     {% include 'lms_banner.html' %}
     <header>


### PR DESCRIPTION
## Summary
- Add `imagehash` to requirements.txt
- Backend: scan_duplicates background job — SHA-256 exact hash grouping + pHash (imagehash) Hamming distance ≤ 10 for near-duplicates
- POST /api/scan-duplicates — starts background job, returns {job_id}
- GET /api/scan-duplicates/<job_id> — SSE progress stream (reuses existing jobs system)
- GET /duplicates — page with Scan button, shows groups side-by-side after scan
- UI: duplicate groups as side-by-side thumbnails, delete button per photo, last photo in group not deletable (enforce client-side)
- Empty state: 'No duplicates found'
- Nav link 'Duplicates' on ALL pages: library, albums, album_detail, people, person_detail, person_form, search, options, detail, map

Closes #81