### PR TITLE
Add bulk download feature

### DIFF
--- a/templates/album_detail.html
+++ b/templates/album_detail.html
@@ -243,6 +243,103 @@
       border: 1px dashed var(--border);
       border-radius: calc(var(--radius) - 4px);
     }
+    .select-toggle {
+      padding: 0.55rem 0.85rem;
+      font-size: 0.85rem;
+      font-weight: 600;
+      font-family: inherit;
+      color: var(--text);
+      background: var(--bg-input);
+      border: 1px solid var(--border);
+      border-radius: calc(var(--radius) - 4px);
+      cursor: pointer;
+    }
+    .select-toggle:hover { border-color: var(--accent); }
+    .select-toggle.is-active {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: var(--bg);
+    }
+    .thumb-check {
+      position: absolute;
+      top: 0.35rem;
+      left: 0.35rem;
+      width: 22px;
+      height: 22px;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      font-size: 1rem;
+      color: var(--bg);
+      background: rgba(91, 159, 212, 0.85);
+      border-radius: 4px;
+      cursor: pointer;
+      border: 2px solid var(--bg);
+      z-index: 1;
+    }
+    .thumb-card.is-selected .thumb-check { display: flex; }
+    .select-mode .thumb-check { display: flex; }
+    .thumb-check.is-checked {
+      background: var(--accent);
+    }
+    .thumb-check.is-checked::after {
+      content: "✓";
+    }
+    .bulk-actions {
+      display: none;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      padding: 0.65rem 0.85rem;
+      background: var(--bg-elevated);
+      border: 1px solid var(--accent);
+      border-radius: calc(var(--radius) - 4px);
+      margin-bottom: 0.75rem;
+    }
+    .bulk-actions.visible { display: flex; }
+    .bulk-count {
+      flex: 1 1 100%;
+      font-size: 0.9rem;
+      color: var(--text-muted);
+      margin: 0;
+    }
+    .bulk-btn {
+      padding: 0.5rem 0.85rem;
+      font-size: 0.85rem;
+      font-weight: 600;
+      font-family: inherit;
+      border: none;
+      border-radius: calc(var(--radius) - 4px);
+      cursor: pointer;
+      min-height: 40px;
+    }
+    .bulk-btn--download {
+      color: var(--bg);
+      background: var(--accent);
+    }
+    .bulk-btn--download:hover {
+      background: var(--accent-hover);
+    }
+    .toolbar-row { display: flex; gap: 0.5rem; align-items: stretch; margin-bottom: 0.75rem; }
+    .download-toast {
+      position: fixed;
+      bottom: 1.5rem;
+      left: 50%;
+      transform: translateX(-50%) translateY(100%);
+      padding: 0.75rem 1.25rem;
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: var(--bg);
+      background: var(--accent);
+      border-radius: calc(var(--radius) - 4px);
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+      z-index: 2000;
+      opacity: 0;
+      transition: transform 0.25s ease, opacity 0.25s ease;
+    }
+    .download-toast.visible {
+      transform: translateX(-50%) translateY(0);
+      opacity: 1;
+    }
   </style>
 </head>
 <body>
@@ -274,13 +371,21 @@
       <p class="hint">Enter filenames from your library, separated by commas.</p>
     </section>
     {% if photos %}
+    <div class="toolbar-row">
+      <button type="button" class="select-toggle" id="select-toggle">Select</button>
+    </div>
+    <div class="bulk-actions" id="bulk-actions">
+      <p class="bulk-count" id="bulk-count">0 selected</p>
+      <button type="button" class="bulk-btn bulk-btn--download" id="bulk-download">Download zip</button>
+    </div>
     <ul class="thumb-grid">
       {% for filename in photos %}
       {% set parts = filename.rsplit('.', 1) %}
       {% set ext = parts[1].lower() if parts|length == 2 else '' %}
       {% set is_img = ext in ['png', 'jpg', 'jpeg', 'gif'] %}
       <li>
-        <div class="thumb-card">
+        <div class="thumb-card" data-filename="{{ filename|e }}">
+          <button type="button" class="thumb-check" aria-label="Select {{ filename|e }}"></button>
           <a class="thumb-preview" href="{{ url_for('file_detail', filename=filename) }}" title="Details for {{ filename|e }}">
             {% if is_img %}
             <img src="{{ url_for('uploaded_file', filename=filename) }}" alt="" loading="lazy" width="200" height="200">
@@ -307,5 +412,110 @@
     </div>
     {% endif %}
   </div>
+  <div class="download-toast" id="download-toast"></div>
+  <script>
+    (function() {
+      var selectToggle = document.getElementById('select-toggle');
+      var bulkActions = document.getElementById('bulk-actions');
+      var bulkCount = document.getElementById('bulk-count');
+      var bulkDownload = document.getElementById('bulk-download');
+      var thumbGrid = document.querySelector('.thumb-grid');
+      var selectMode = false;
+      var selectedFiles = new Set();
+
+      function getFilename(el) {
+        var card = el.closest('.thumb-card');
+        return card ? card.getAttribute('data-filename') : null;
+      }
+
+      function updateBulkUI() {
+        var count = selectedFiles.size;
+        bulkCount.textContent = count + ' selected';
+        bulkActions.classList.toggle('visible', count > 0);
+      }
+
+      function toggleSelection(filename) {
+        var card = document.querySelector('.thumb-card[data-filename="' + filename + '"]');
+        var check = card ? card.querySelector('.thumb-check') : null;
+        if (selectedFiles.has(filename)) {
+          selectedFiles.delete(filename);
+          if (card) card.classList.remove('is-selected');
+          if (check) check.classList.remove('is-checked');
+        } else {
+          selectedFiles.add(filename);
+          if (card) card.classList.add('is-selected');
+          if (check) check.classList.add('is-checked');
+        }
+        updateBulkUI();
+      }
+
+      function showToast(message) {
+        var toast = document.getElementById('download-toast');
+        if (!toast) return;
+        toast.textContent = message;
+        toast.classList.add('visible');
+        setTimeout(function() {
+          toast.classList.remove('visible');
+        }, 3000);
+      }
+
+      if (!selectToggle) return;
+
+      selectToggle.addEventListener('click', function() {
+        if (selectedFiles.size > 0) {
+          selectedFiles.clear();
+          document.querySelectorAll('.thumb-card').forEach(function(card) {
+            card.classList.remove('is-selected');
+            var check = card.querySelector('.thumb-check');
+            if (check) check.classList.remove('is-checked');
+          });
+        }
+        selectMode = !selectMode;
+        selectToggle.classList.toggle('is-active', selectMode);
+        bulkActions.classList.toggle('visible', selectMode && selectedFiles.size > 0);
+        if (thumbGrid) thumbGrid.classList.toggle('select-mode', selectMode);
+        if (!selectMode) {
+          selectToggle.textContent = 'Select';
+        } else {
+          bulkCount.textContent = '0 selected';
+        }
+      });
+
+      document.addEventListener('click', function(e) {
+        var check = e.target.closest('.thumb-check');
+        if (check) {
+          e.preventDefault();
+          var filename = getFilename(check);
+          if (filename) toggleSelection(filename);
+          return;
+        }
+        if (!selectMode) return;
+        var card = e.target.closest('.thumb-card');
+        if (!card) return;
+        if (e.target.closest('a') || e.target.closest('form')) return;
+        var filename = getFilename(card);
+        if (filename) {
+          e.preventDefault();
+          toggleSelection(filename);
+        }
+      });
+
+      bulkDownload.addEventListener('click', function() {
+        var arr = Array.from(selectedFiles);
+        if (arr.length === 0) return;
+        showToast('Downloading ' + arr.length + ' photo(s)...');
+        var form = document.createElement('form');
+        form.method = 'POST';
+        form.action = '/bulk/download';
+        var filenames = document.createElement('input');
+        filenames.type = 'hidden';
+        filenames.name = 'filenames';
+        filenames.value = arr.join(',');
+        form.appendChild(filenames);
+        document.body.appendChild(form);
+        form.submit();
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/templates/library.html
+++ b/templates/library.html
@@ -604,6 +604,26 @@
       color: var(--bg);
       background: var(--accent);
     }
+    .download-toast {
+      position: fixed;
+      bottom: 1.5rem;
+      left: 50%;
+      transform: translateX(-50%) translateY(100%);
+      padding: 0.75rem 1.25rem;
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: var(--bg);
+      background: var(--accent);
+      border-radius: calc(var(--radius) - 4px);
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+      z-index: 2000;
+      opacity: 0;
+      transition: transform 0.25s ease, opacity 0.25s ease;
+    }
+    .download-toast.visible {
+      transform: translateX(-50%) translateY(0);
+      opacity: 1;
+    }
   </style>
 </head>
 <body>
@@ -772,6 +792,7 @@
         </div>
       </div>
     </div>
+    <div class="download-toast" id="download-toast"></div>
   </div>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
   <script>
@@ -965,6 +986,7 @@
       bulkDownload.addEventListener('click', function() {
         var arr = Array.from(selectedFiles);
         if (arr.length === 0) return;
+        showToast('Downloading ' + arr.length + ' photo(s)...');
         var form = document.createElement('form');
         form.method = 'POST';
         form.action = '/bulk/download';
@@ -1010,6 +1032,15 @@
         }
       });
     })();
+    function showToast(message) {
+      var toast = document.getElementById('download-toast');
+      if (!toast) return;
+      toast.textContent = message;
+      toast.classList.add('visible');
+      setTimeout(function() {
+        toast.classList.remove('visible');
+      }, 3000);
+    }
   </script>
 </body>
 </html>

--- a/templates/person_detail.html
+++ b/templates/person_detail.html
@@ -210,6 +210,106 @@
       border: 1px dashed var(--border);
       border-radius: calc(var(--radius) - 4px);
     }
+    .select-toggle {
+      padding: 0.55rem 0.85rem;
+      font-size: 0.85rem;
+      font-weight: 600;
+      font-family: inherit;
+      color: var(--text);
+      background: var(--bg-input);
+      border: 1px solid var(--border);
+      border-radius: calc(var(--radius) - 4px);
+      cursor: pointer;
+    }
+    .select-toggle:hover { border-color: var(--accent); }
+    .select-toggle.is-active {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: var(--bg);
+    }
+    .thumb-check {
+      position: absolute;
+      top: 0.35rem;
+      left: 0.35rem;
+      width: 22px;
+      height: 22px;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      font-size: 1rem;
+      color: var(--bg);
+      background: rgba(91, 159, 212, 0.85);
+      border-radius: 4px;
+      cursor: pointer;
+      border: 2px solid var(--bg);
+      z-index: 1;
+    }
+    .photo-thumb.is-selected .thumb-check { display: flex; }
+    .select-mode .thumb-check { display: flex; }
+    .thumb-check.is-checked {
+      background: var(--accent);
+    }
+    .thumb-check.is-checked::after {
+      content: "✓";
+    }
+    .bulk-actions {
+      display: none;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      padding: 0.65rem 0.85rem;
+      background: var(--bg-elevated);
+      border: 1px solid var(--accent);
+      border-radius: calc(var(--radius) - 4px);
+      margin-bottom: 0.75rem;
+    }
+    .bulk-actions.visible { display: flex; }
+    .bulk-count {
+      flex: 1 1 100%;
+      font-size: 0.9rem;
+      color: var(--text-muted);
+      margin: 0;
+    }
+    .bulk-btn {
+      padding: 0.5rem 0.85rem;
+      font-size: 0.85rem;
+      font-weight: 600;
+      font-family: inherit;
+      border: none;
+      border-radius: calc(var(--radius) - 4px);
+      cursor: pointer;
+      min-height: 40px;
+    }
+    .bulk-btn--download {
+      color: var(--bg);
+      background: var(--accent);
+    }
+    .bulk-btn--download:hover {
+      background: var(--accent-hover);
+    }
+    .toolbar-row { display: flex; gap: 0.5rem; align-items: stretch; margin-bottom: 0.75rem; }
+    .photo-thumb {
+      position: relative;
+    }
+    .download-toast {
+      position: fixed;
+      bottom: 1.5rem;
+      left: 50%;
+      transform: translateX(-50%) translateY(100%);
+      padding: 0.75rem 1.25rem;
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: var(--bg);
+      background: var(--accent);
+      border-radius: calc(var(--radius) - 4px);
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+      z-index: 2000;
+      opacity: 0;
+      transition: transform 0.25s ease, opacity 0.25s ease;
+    }
+    .download-toast.visible {
+      transform: translateX(-50%) translateY(0);
+      opacity: 1;
+    }
   </style>
 </head>
 <body>
@@ -259,15 +359,25 @@
 
     <div class="section">
       <h2 class="section-title">Tagged Photos</h2>
-      {% if tagged_photos %}
+    {% if tagged_photos %}
+      <div class="toolbar-row">
+        <button type="button" class="select-toggle" id="select-toggle">Select</button>
+      </div>
+      <div class="bulk-actions" id="bulk-actions">
+        <p class="bulk-count" id="bulk-count">0 selected</p>
+        <button type="button" class="bulk-btn bulk-btn--download" id="bulk-download">Download zip</button>
+      </div>
       <div class="photos-grid">
         {% for path, meta in tagged_photos %}
-        <a class="photo-thumb" href="{{ url_for('file_detail', filename=path.name) }}">
-          <img src="{{ url_for('uploaded_file', filename=path.name) }}" alt="" loading="lazy">
-        </a>
+        <div class="photo-thumb" data-filename="{{ path.name|e }}">
+          <button type="button" class="thumb-check" aria-label="Select {{ path.name|e }}"></button>
+          <a href="{{ url_for('file_detail', filename=path.name) }}">
+            <img src="{{ url_for('uploaded_file', filename=path.name) }}" alt="" loading="lazy">
+          </a>
+        </div>
         {% endfor %}
       </div>
-      {% else %}
+    {% else %}
       <div class="empty">No photos tagged with this person</div>
       {% endif %}
     </div>
@@ -320,5 +430,112 @@
         });
     }
   </script>
+  {% if tagged_photos %}
+  <script>
+    (function() {
+      var selectToggle = document.getElementById('select-toggle');
+      var bulkActions = document.getElementById('bulk-actions');
+      var bulkCount = document.getElementById('bulk-count');
+      var bulkDownload = document.getElementById('bulk-download');
+      var photosGrid = document.querySelector('.photos-grid');
+      var selectMode = false;
+      var selectedFiles = new Set();
+
+      function getFilename(el) {
+        var card = el.closest('.photo-thumb');
+        return card ? card.getAttribute('data-filename') : null;
+      }
+
+      function updateBulkUI() {
+        var count = selectedFiles.size;
+        bulkCount.textContent = count + ' selected';
+        bulkActions.classList.toggle('visible', count > 0);
+      }
+
+      function toggleSelection(filename) {
+        var card = document.querySelector('.photo-thumb[data-filename="' + filename + '"]');
+        var check = card ? card.querySelector('.thumb-check') : null;
+        if (selectedFiles.has(filename)) {
+          selectedFiles.delete(filename);
+          if (card) card.classList.remove('is-selected');
+          if (check) check.classList.remove('is-checked');
+        } else {
+          selectedFiles.add(filename);
+          if (card) card.classList.add('is-selected');
+          if (check) check.classList.add('is-checked');
+        }
+        updateBulkUI();
+      }
+
+      function showToast(message) {
+        var toast = document.getElementById('download-toast');
+        if (!toast) return;
+        toast.textContent = message;
+        toast.classList.add('visible');
+        setTimeout(function() {
+          toast.classList.remove('visible');
+        }, 3000);
+      }
+
+      if (!selectToggle) return;
+
+      selectToggle.addEventListener('click', function() {
+        if (selectedFiles.size > 0) {
+          selectedFiles.clear();
+          document.querySelectorAll('.photo-thumb').forEach(function(card) {
+            card.classList.remove('is-selected');
+            var check = card.querySelector('.thumb-check');
+            if (check) check.classList.remove('is-checked');
+          });
+        }
+        selectMode = !selectMode;
+        selectToggle.classList.toggle('is-active', selectMode);
+        bulkActions.classList.toggle('visible', selectMode && selectedFiles.size > 0);
+        if (photosGrid) photosGrid.classList.toggle('select-mode', selectMode);
+        if (!selectMode) {
+          selectToggle.textContent = 'Select';
+        } else {
+          bulkCount.textContent = '0 selected';
+        }
+      });
+
+      document.addEventListener('click', function(e) {
+        var check = e.target.closest('.thumb-check');
+        if (check) {
+          e.preventDefault();
+          var filename = getFilename(check);
+          if (filename) toggleSelection(filename);
+          return;
+        }
+        if (!selectMode) return;
+        var card = e.target.closest('.photo-thumb');
+        if (!card) return;
+        if (e.target.closest('a') || e.target.closest('form')) return;
+        var filename = getFilename(card);
+        if (filename) {
+          e.preventDefault();
+          toggleSelection(filename);
+        }
+      });
+
+      bulkDownload.addEventListener('click', function() {
+        var arr = Array.from(selectedFiles);
+        if (arr.length === 0) return;
+        showToast('Downloading ' + arr.length + ' photo(s)...');
+        var form = document.createElement('form');
+        form.method = 'POST';
+        form.action = '/bulk/download';
+        var filenames = document.createElement('input');
+        filenames.type = 'hidden';
+        filenames.name = 'filenames';
+        filenames.value = arr.join(',');
+        form.appendChild(filenames);
+        document.body.appendChild(form);
+        form.submit();
+      });
+    })();
+  </script>
+  {% endif %}
+  <div class="download-toast" id="download-toast"></div>
 </body>
 </html>

--- a/templates/search.html
+++ b/templates/search.html
@@ -320,6 +320,103 @@
       text-decoration: none;
     }
     .add-link:hover { background: var(--accent-hover); }
+    .select-toggle {
+      padding: 0.55rem 0.85rem;
+      font-size: 0.85rem;
+      font-weight: 600;
+      font-family: inherit;
+      color: var(--text);
+      background: var(--bg-input);
+      border: 1px solid var(--border);
+      border-radius: calc(var(--radius) - 4px);
+      cursor: pointer;
+    }
+    .select-toggle:hover { border-color: var(--accent); }
+    .select-toggle.is-active {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: var(--bg);
+    }
+    .thumb-check {
+      position: absolute;
+      top: 0.35rem;
+      left: 0.35rem;
+      width: 22px;
+      height: 22px;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      font-size: 1rem;
+      color: var(--bg);
+      background: rgba(91, 159, 212, 0.85);
+      border-radius: 4px;
+      cursor: pointer;
+      border: 2px solid var(--bg);
+      z-index: 1;
+    }
+    .thumb-card.is-selected .thumb-check { display: flex; }
+    .select-mode .thumb-check { display: flex; }
+    .thumb-check.is-checked {
+      background: var(--accent);
+    }
+    .thumb-check.is-checked::after {
+      content: "✓";
+    }
+    .bulk-actions {
+      display: none;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      padding: 0.65rem 0.85rem;
+      background: var(--bg-elevated);
+      border: 1px solid var(--accent);
+      border-radius: calc(var(--radius) - 4px);
+      margin-bottom: 0.75rem;
+    }
+    .bulk-actions.visible { display: flex; }
+    .bulk-count {
+      flex: 1 1 100%;
+      font-size: 0.9rem;
+      color: var(--text-muted);
+      margin: 0;
+    }
+    .bulk-btn {
+      padding: 0.5rem 0.85rem;
+      font-size: 0.85rem;
+      font-weight: 600;
+      font-family: inherit;
+      border: none;
+      border-radius: calc(var(--radius) - 4px);
+      cursor: pointer;
+      min-height: 40px;
+    }
+    .bulk-btn--download {
+      color: var(--bg);
+      background: var(--accent);
+    }
+    .bulk-btn--download:hover {
+      background: var(--accent-hover);
+    }
+    .toolbar-row { display: flex; gap: 0.5rem; align-items: stretch; margin-bottom: 0.75rem; }
+    .download-toast {
+      position: fixed;
+      bottom: 1.5rem;
+      left: 50%;
+      transform: translateX(-50%) translateY(100%);
+      padding: 0.75rem 1.25rem;
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: var(--bg);
+      background: var(--accent);
+      border-radius: calc(var(--radius) - 4px);
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+      z-index: 2000;
+      opacity: 0;
+      transition: transform 0.25s ease, opacity 0.25s ease;
+    }
+    .download-toast.visible {
+      transform: translateX(-50%) translateY(0);
+      opacity: 1;
+    }
   </style>
 </head>
 <body>
@@ -374,6 +471,13 @@
     <section aria-labelledby="results-heading">
       <h2 id="results-heading">{{ results|length }} result{% if results|length != 1 %}s{% endif %}</h2>
       {% if results %}
+      <div class="toolbar-row">
+        <button type="button" class="select-toggle" id="select-toggle">Select</button>
+      </div>
+      <div class="bulk-actions" id="bulk-actions">
+        <p class="bulk-count" id="bulk-count">0 selected</p>
+        <button type="button" class="bulk-btn bulk-btn--download" id="bulk-download">Download zip</button>
+      </div>
       <ul class="thumb-grid">
         {% for path, meta, match_reason in results %}
         {% set filename = path.name %}
@@ -381,21 +485,22 @@
         {% set ext = parts[1].lower() if parts|length == 2 else '' %}
         {% set is_img = ext in ['png', 'jpg', 'jpeg', 'gif'] %}
         <li>
-          <a class="thumb-card" href="{{ url_for('file_detail', filename=filename) }}">
-            <div class="thumb-preview">
+          <div class="thumb-card" data-filename="{{ filename|e }}">
+            <button type="button" class="thumb-check" aria-label="Select {{ filename|e }}"></button>
+            <a class="thumb-preview" href="{{ url_for('file_detail', filename=filename) }}">
               {% if is_img %}
               <img src="{{ url_for('uploaded_file', filename=filename) }}" alt="" loading="lazy" width="200" height="200">
               {% else %}
               <span class="thumb-placeholder"><span>{{ ext|upper if ext else 'FILE' }}</span></span>
               {% endif %}
-            </div>
+            </a>
             <div class="thumb-meta">
               <span class="thumb-name">{{ filename }}</span>
               {% if match_reason %}
               <span class="thumb-reason">{{ match_reason }}</span>
               {% endif %}
             </div>
-          </a>
+          </div>
         </li>
         {% endfor %}
       </ul>
@@ -405,6 +510,7 @@
     </section>
     {% endif %}
   </div>
+  <div class="download-toast" id="download-toast"></div>
   {% if mode == 'person' and people %}
   <script>
     function streamJob(jobId, onProgress, onDone) {
@@ -486,6 +592,112 @@
           progress.classList.add('error');
           msg.textContent = 'Error: ' + err.message;
         });
+      });
+    })();
+  </script>
+  {% endif %}
+  {% if query and results %}
+  <script>
+    (function() {
+      var selectToggle = document.getElementById('select-toggle');
+      var bulkActions = document.getElementById('bulk-actions');
+      var bulkCount = document.getElementById('bulk-count');
+      var bulkDownload = document.getElementById('bulk-download');
+      var thumbGrid = document.querySelector('.thumb-grid');
+      var selectMode = false;
+      var selectedFiles = new Set();
+
+      function getFilename(el) {
+        var card = el.closest('.thumb-card');
+        return card ? card.getAttribute('data-filename') : null;
+      }
+
+      function updateBulkUI() {
+        var count = selectedFiles.size;
+        bulkCount.textContent = count + ' selected';
+        bulkActions.classList.toggle('visible', count > 0);
+      }
+
+      function toggleSelection(filename) {
+        var card = document.querySelector('.thumb-card[data-filename="' + filename + '"]');
+        var check = card ? card.querySelector('.thumb-check') : null;
+        if (selectedFiles.has(filename)) {
+          selectedFiles.delete(filename);
+          if (card) card.classList.remove('is-selected');
+          if (check) check.classList.remove('is-checked');
+        } else {
+          selectedFiles.add(filename);
+          if (card) card.classList.add('is-selected');
+          if (check) check.classList.add('is-checked');
+        }
+        updateBulkUI();
+      }
+
+      function showToast(message) {
+        var toast = document.getElementById('download-toast');
+        if (!toast) return;
+        toast.textContent = message;
+        toast.classList.add('visible');
+        setTimeout(function() {
+          toast.classList.remove('visible');
+        }, 3000);
+      }
+
+      if (!selectToggle) return;
+
+      selectToggle.addEventListener('click', function() {
+        if (selectedFiles.size > 0) {
+          selectedFiles.clear();
+          document.querySelectorAll('.thumb-card').forEach(function(card) {
+            card.classList.remove('is-selected');
+            var check = card.querySelector('.thumb-check');
+            if (check) check.classList.remove('is-checked');
+          });
+        }
+        selectMode = !selectMode;
+        selectToggle.classList.toggle('is-active', selectMode);
+        bulkActions.classList.toggle('visible', selectMode && selectedFiles.size > 0);
+        if (thumbGrid) thumbGrid.classList.toggle('select-mode', selectMode);
+        if (!selectMode) {
+          selectToggle.textContent = 'Select';
+        } else {
+          bulkCount.textContent = '0 selected';
+        }
+      });
+
+      document.addEventListener('click', function(e) {
+        var check = e.target.closest('.thumb-check');
+        if (check) {
+          e.preventDefault();
+          var filename = getFilename(check);
+          if (filename) toggleSelection(filename);
+          return;
+        }
+        if (!selectMode) return;
+        var card = e.target.closest('.thumb-card');
+        if (!card) return;
+        if (e.target.closest('a') || e.target.closest('form')) return;
+        var filename = getFilename(card);
+        if (filename) {
+          e.preventDefault();
+          toggleSelection(filename);
+        }
+      });
+
+      bulkDownload.addEventListener('click', function() {
+        var arr = Array.from(selectedFiles);
+        if (arr.length === 0) return;
+        showToast('Downloading ' + arr.length + ' photo(s)...');
+        var form = document.createElement('form');
+        form.method = 'POST';
+        form.action = '/bulk/download';
+        var filenames = document.createElement('input');
+        filenames.type = 'hidden';
+        filenames.name = 'filenames';
+        filenames.value = arr.join(',');
+        form.appendChild(filenames);
+        document.body.appendChild(form);
+        form.submit();
       });
     })();
   </script>


### PR DESCRIPTION
## Summary

- Add completion toast notification to library.html when downloading selected photos
- Add bulk selection UI + download to album_detail.html, search.html, and person_detail.html
- Toast auto-dismisses after 3 seconds
- All views use existing `/bulk/download` endpoint

## Changes

| File | What changed |
|------|-------------|
| `library.html` | Added download toast notification on bulk download submit |
| `album_detail.html` | Added select toggle, checkbox overlays, bulk actions bar, download button, toast |
| `search.html` | Added select toggle, checkbox overlays, bulk actions bar, download button, toast |
| `person_detail.html` | Added select toggle, checkbox overlays, bulk actions bar, download button, toast |

## Acceptance Criteria

- [x] In `library.html`: clicking "Download selected" shows a toast/banner confirming download started
- [x] In `album_detail.html`: user can enter select mode, pick photos, and download as ZIP with completion toast
- [x] In `search.html`: user can enter select mode, pick photos, and download as ZIP with completion toast
- [x] In `person_detail.html`: user can enter select mode, pick photos, and download as ZIP with completion toast
- [x] Toast disappears after ~3 seconds automatically
- [x] Select mode UI matches existing style in `library.html` (toggle button, checkbox overlay, count badge)
- [x] No new backend routes needed — all views POST to existing `/bulk/download`

closes #91